### PR TITLE
Fine Grain Permission Screen added with functionality and role assignment 

### DIFF
--- a/src/components/ConfirmDeleteDialog.tsx
+++ b/src/components/ConfirmDeleteDialog.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
+
+type ConfirmDeleteDialogProps = {
+  open: boolean;
+  title?: string;
+  entityName?: string;
+  description?: string;
+  warningText?: string;
+  loading?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  cancelButtonSx?: any;
+};
+
+function ConfirmDeleteDialog({
+  open,
+  title = "Delete",
+  entityName = "",
+  description = "",
+  warningText = "This action is permanent and cannot be undone.",
+  loading = false,
+  onCancel,
+  onConfirm,
+  confirmLabel = "Delete",
+  cancelLabel = "Cancel",
+  cancelButtonSx,
+}: ConfirmDeleteDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      fullWidth
+      maxWidth="xs"
+      PaperProps={{
+        sx: {
+          borderRadius: 2,
+          boxShadow: "0 16px 40px rgba(0,0,0,0.25)",
+        },
+      }}
+    >
+      <DialogTitle
+        sx={{
+          fontWeight: 700,
+          pb: 1,
+          borderBottom: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+          {title}
+        </Typography>
+      </DialogTitle>
+      <DialogContent sx={{ pt: 2.25 }}>
+        <DialogContentText sx={{ color: "text.primary", mb: 0.75 }}>
+          Are you sure you want to delete <strong>"{entityName}"</strong>?
+        </DialogContentText>
+        {description ? (
+          <DialogContentText sx={{ color: "text.secondary", mb: 1.5 }}>
+            {description}
+          </DialogContentText>
+        ) : null}
+        <Alert
+          severity="warning"
+          sx={{
+            borderRadius: 1.5,
+            backgroundColor: "rgba(237, 108, 2, 0.12)",
+            color: "warning.dark",
+            "& .MuiAlert-message": { fontWeight: 500 },
+          }}
+        >
+          {warningText}
+        </Alert>
+      </DialogContent>
+      <DialogActions
+        sx={{
+          px: 3,
+          pb: 2.25,
+          pt: 1.5,
+          gap: 1,
+          borderTop: "1px solid",
+          borderColor: "divider",
+        }}
+      >
+        <Button onClick={onCancel} disabled={loading} variant="outlined" sx={cancelButtonSx}>
+          {cancelLabel}
+        </Button>
+        <Button onClick={onConfirm} disabled={loading} color="error" variant="contained">
+          {loading ? "Deleting..." : confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default ConfirmDeleteDialog;

--- a/src/components/GraphObservationsPerDatastream.tsx
+++ b/src/components/GraphObservationsPerDatastream.tsx
@@ -214,7 +214,7 @@ function GraphObservationsPerDatastream({
     const backend_url = process.env.REACT_APP_FROST_URL;
     axios
       .get(
-        `https://${frostServerPort}-${backend_url}/FROST-Server/v1.0/Datastreams(${id})/Observations?$orderby=phenomenonTime desc&$top=50`,
+        `https://${frostServerPort}-${backend_url}/FROST-Server/v1.0/Datastreams(${id})/Observations?$orderby=phenomenonTime desc&$top=100`,
         {
           headers: {
             "Content-Type": "application/json",

--- a/src/components/GraphObservationsPerDatastream.tsx
+++ b/src/components/GraphObservationsPerDatastream.tsx
@@ -25,6 +25,10 @@ declare const process: any;
 const formatLocalDateTime = (value: string | Date) =>
   format(new Date(value), "dd.MM.yyyy HH:mm");
 
+// Balanced for production: fewer requests than 100, safer payload size than 1000.
+const OBSERVATIONS_PAGE_SIZE = 500;
+const GRAPH_INITIAL_POINTS = 100;
+
 function GraphObservationsPerDatastream({
   token,
   frostServerPort,
@@ -214,7 +218,7 @@ function GraphObservationsPerDatastream({
     const backend_url = process.env.REACT_APP_FROST_URL;
     axios
       .get(
-        `https://${frostServerPort}-${backend_url}/FROST-Server/v1.0/Datastreams(${id})/Observations?$orderby=phenomenonTime desc&$top=100`,
+        `https://${frostServerPort}-${backend_url}/FROST-Server/v1.0/Datastreams(${id})/Observations?$orderby=phenomenonTime desc&$top=${GRAPH_INITIAL_POINTS}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -293,7 +297,7 @@ function GraphObservationsPerDatastream({
       const filterQuery = `phenomenonTime ge ${startDate} and phenomenonTime le ${endDate}`;
       const baseUrl = `https://${frostServerPort}-${backend_url}/FROST-Server/v1.0/Datastreams(${id})/Observations?$filter=${encodeURIComponent(
         filterQuery
-      )}&$orderby=phenomenonTime&$top=100`;
+      )}&$orderby=phenomenonTime&$top=${OBSERVATIONS_PAGE_SIZE}`;
   
       const observations = await fetchAllObservations(baseUrl, token);
 

--- a/src/components/GroupIntializer.tsx
+++ b/src/components/GroupIntializer.tsx
@@ -29,12 +29,24 @@ useEffect(() => {
 
         const savedGroupId = localStorage.getItem("group_id");
         const validGroup = groups.find((g: any) => g.group_name_id === savedGroupId);
+        const wasRemovedFromSelectedGroup = Boolean(savedGroupId) && !validGroup;
 
         // Prioritize localStorage value if it's valid
-        const finalGroupId = validGroup ? validGroup.group_name_id : groups[0]?.group_name_id;
+        const finalGroupId = validGroup ? validGroup.group_name_id : groups[0]?.group_name_id || "";
 
-        dispatch(setSelectedGroupId(finalGroupId));
-        localStorage.setItem("group_id", finalGroupId);
+        if (wasRemovedFromSelectedGroup) {
+          localStorage.removeItem("group_id");
+          dispatch(setSelectedGroupId(""));
+          window.location.assign("/dashboard");
+          return;
+        }
+
+        dispatch(setSelectedGroupId(finalGroupId || ""));
+        if (finalGroupId) {
+          localStorage.setItem("group_id", finalGroupId);
+        } else {
+          localStorage.removeItem("group_id");
+        }
       }
     } catch (err) {
       console.error("Error fetching groups:", err);

--- a/src/components/GroupIntializer.tsx
+++ b/src/components/GroupIntializer.tsx
@@ -42,6 +42,24 @@ useEffect(() => {
   };
 
   fetchGroups();
+
+  const handleFocusRefresh = () => {
+    fetchGroups();
+  };
+
+  const handleVisibilityRefresh = () => {
+    if (document.visibilityState === "visible") {
+      fetchGroups();
+    }
+  };
+
+  window.addEventListener("focus", handleFocusRefresh);
+  document.addEventListener("visibilitychange", handleVisibilityRefresh);
+
+  return () => {
+    window.removeEventListener("focus", handleFocusRefresh);
+    document.removeEventListener("visibilitychange", handleVisibilityRefresh);
+  };
 }, [keycloak.authenticated, keycloak.tokenParsed?.sub]);
 
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,6 +22,8 @@ const Drawer = styled(MuiDrawer)`
 
   > div {
     border-right: 0;
+    background-color: ${(props) => props.theme.sidebar.background};
+    color: ${(props) => props.theme.sidebar.color};
   }
 `;
 

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -56,6 +56,27 @@ const PerfectScrollbar = styled(ReactPerfectScrollbar)`
 const Items = styled.div`
   padding-top: ${(props) => props.theme.spacing(2.5)};
   padding-bottom: ${(props) => props.theme.spacing(2.5)};
+
+  /* Prevent MUI default light highlight flashes inside dark sidebar. */
+  .MuiListItemButton-root {
+    color: #ffffff;
+    background-color: transparent;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .MuiListItemButton-root:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .MuiListItemButton-root.Mui-selected,
+  .MuiListItemButton-root.Mui-selected:hover,
+  .MuiListItemButton-root.Mui-focusVisible {
+    background-color: rgba(255, 255, 255, 0.14);
+  }
+
+  .MuiTouchRipple-root {
+    display: none;
+  }
 `;
 
 type SidebarNavProps = {

--- a/src/hooks/hooks.ts
+++ b/src/hooks/hooks.ts
@@ -9,5 +9,6 @@ export const useIsOwner = (): boolean => {
     const group = useAppSelector((state) =>
       state.roles.groups.find((g) => g.group_name_id === selectedGroupId)
     );
-    return group?.role === "owner";
+    // Keep legacy hook name, but allow write access for owner and editor roles.
+    return group?.role === "owner" || group?.role === "editor";
   };

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -32,7 +32,10 @@ import {
   DialogContent,
   Tabs,
   Tab,
-  Chip
+  Chip,
+  FormControl,
+  InputLabel,
+  Select
 } from "@mui/material";
 import axios, { AxiosError } from "axios";
 import { useLocation } from "react-router-dom";
@@ -44,7 +47,7 @@ import ExitToAppIcon from "@mui/icons-material/ExitToApp"; // Leave Group
 import CheckCircleIcon from "@mui/icons-material/CheckCircle"; // Approve Icon
 import CancelIcon from "@mui/icons-material/Cancel"; // Reject Icon
 import CloseIcon from "@mui/icons-material/Close"; // Close Popover Ico
-import RemoveCircleIcon from "@mui/icons-material/RemoveCircle"; // Remove Member Icon
+import PersonRemoveAlt1Icon from "@mui/icons-material/PersonRemoveAlt1";
 import Tooltip from "@mui/material/Tooltip";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline"
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
@@ -79,6 +82,18 @@ export default function ListClients() {
   const [anchorEl, setAnchorEl] = useState(null);
   const [memberModalGroup, setMemberModalGroup] = useState<any | null>(null);
   const [memberModalTab, setMemberModalTab] = useState<"members" | "pending">("members");
+  const [memberActionDialog, setMemberActionDialog] = useState<{
+    open: boolean;
+    type: "approve" | "reject" | "changeRole";
+    membershipId?: any;
+    memberName?: string;
+    currentRole?: "reader" | "editor";
+    selectedRole: "reader" | "editor";
+  }>({
+    open: false,
+    type: "approve",
+    selectedRole: "reader",
+  });
   const [nodeRedMenuAnchor, setNodeRedMenuAnchor] = useState<null | HTMLElement>(null);
   const [nodeRedTargetGroup, setNodeRedTargetGroup] = useState<any>(null);
 
@@ -323,61 +338,84 @@ export default function ListClients() {
     }
   };
 
-  const handleAction = async (action: string, userId: any) => {
-    const isApproveAction = action === "approve";
-    const token = keycloak?.token;
-
-    const confirmation = await Swal.fire({
-      title: `Are you sure you want to ${action} this request?`,
-      icon: "warning",
-      showCancelButton: true,
-      confirmButtonText: "Yes",
-      cancelButtonText: "No",
-      input: isApproveAction ? "select" : undefined,
-      inputValue: isApproveAction ? "reader" : undefined,
-      inputOptions: isApproveAction
-        ? { reader: "Reader", editor: "Editor" }
-        : undefined,
-      inputPlaceholder: isApproveAction ? "Select role" : undefined,
-      inputValidator: isApproveAction
-        ? (value: string) => {
-            if (!value || !["reader", "editor"].includes(value)) {
-              return "Please select a valid role.";
-            }
-            return null;
-          }
-        : undefined,
+  const openMemberActionDialog = (
+    type: "approve" | "reject" | "changeRole",
+    member: any
+  ) => {
+    const memberName = `${member?.first_name || ""} ${member?.last_name || ""}`.trim();
+    const currentRole = member?.role === "editor" ? "editor" : "reader";
+    setMemberActionDialog({
+      open: true,
+      type,
+      membershipId: member?.membership_id,
+      memberName,
+      currentRole,
+      selectedRole: type === "changeRole" ? currentRole : "reader",
     });
+  };
 
-    if (!confirmation.isConfirmed) return;
+  const closeMemberActionDialog = () => {
+    setMemberActionDialog((prev) => ({ ...prev, open: false }));
+  };
 
-    const selectedRole = isApproveAction ? confirmation.value : undefined;
-    if (isApproveAction && !["reader", "editor"].includes(selectedRole)) {
-      Swal.fire("Validation Error", "Selected role is invalid.", "error");
+  const submitMemberActionDialog = async () => {
+    const token = keycloak?.token;
+    if (!token) {
+      toast.error("Authentication token not found.");
+      return;
+    }
+    if (!memberActionDialog.membershipId) {
+      toast.error("Membership ID is missing.");
       return;
     }
 
-    const data = {
-      membership_id: userId,
-      action,
-      ...(isApproveAction ? { role: selectedRole } : {}),
-    };
-
     try {
-      const response = await axios.post(
-        `${process.env.REACT_APP_BACKEND_URL}/manage_membership`,
-        data,
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-      Swal.fire("Success", response.data.message, "success");
+      if (memberActionDialog.type === "approve" || memberActionDialog.type === "reject") {
+        const action = memberActionDialog.type;
+        const payload = {
+          membership_id: memberActionDialog.membershipId,
+          action,
+          ...(action === "approve" ? { role: memberActionDialog.selectedRole } : {}),
+        };
+        const response = await axios.post(
+          `${process.env.REACT_APP_BACKEND_URL}/manage_membership`,
+          payload,
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        toast.success(response?.data?.message || "Membership updated.");
+      }
+
+      if (memberActionDialog.type === "changeRole") {
+        if (memberActionDialog.selectedRole === memberActionDialog.currentRole) {
+          toast.info("Selected role is already assigned.");
+          closeMemberActionDialog();
+          return;
+        }
+
+        const payload = {
+          membership_id: memberActionDialog.membershipId,
+          role: memberActionDialog.selectedRole,
+        };
+        try {
+          await axios.post(
+            `${process.env.REACT_APP_BACKEND_URL}/change_member_role`,
+            payload,
+            { headers: { Authorization: `Bearer ${token}` } }
+          );
+        } catch {
+          await axios.post(
+            `${process.env.REACT_APP_BACKEND_URL}/manage_membership`,
+            { membership_id: memberActionDialog.membershipId, action: "change_role", role: memberActionDialog.selectedRole },
+            { headers: { Authorization: `Bearer ${token}` } }
+          );
+        }
+        toast.success("Member role updated successfully.");
+      }
+
+      closeMemberActionDialog();
       getAllGroups();
     } catch (error: any) {
-      Swal.fire(
-        "Error",
-        error?.response?.data?.message ||
-          "Failed to update membership. Please verify role and membership status.",
-        "error"
-      );
+      toast.error(error?.response?.data?.message || "Failed to update member.");
     }
   };
   const openMemberModal = (group: any, tab: "members" | "pending") => {
@@ -388,6 +426,7 @@ export default function ListClients() {
   const closeMemberModal = () => {
     setMemberModalGroup(null);
     setMemberModalTab("members");
+    closeMemberActionDialog();
   };
   const approvedMembers =
     memberModalGroup?.members?.filter((x: any) => x?.membership_status === "approved") || [];
@@ -1064,7 +1103,12 @@ const handleApplyNodeRed = async (groupId: string) => {
           </Box>
           <Tabs
             value={memberModalTab}
-            onChange={(_, newTab) => setMemberModalTab(newTab)}
+            onChange={(_, newTab) => {
+              setMemberModalTab(newTab);
+              if (memberActionDialog.open) {
+                closeMemberActionDialog();
+              }
+            }}
             sx={(theme) => ({
               mb: 2,
               borderBottom: `1px solid ${theme.palette.divider}`,
@@ -1088,6 +1132,83 @@ const handleApplyNodeRed = async (groupId: string) => {
             <Tab label={`Pending Requests (${pendingMembers.length})`} value="pending" />
           </Tabs>
 
+          {memberActionDialog.open && (
+            <Box
+              sx={(theme) => ({
+                mb: 2,
+                p: 2,
+                border: `1px solid ${theme.palette.divider}`,
+                borderRadius: 1,
+                backgroundColor: "background.default",
+                boxShadow: theme.shadows[0],
+              })}
+            >
+              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                {memberActionDialog.type === "approve" && "Approve Request"}
+                {memberActionDialog.type === "reject" && "Reject Request"}
+                {memberActionDialog.type === "changeRole" && "Change Member Role"}
+              </Typography>
+              <Typography variant="body2" sx={{ mt: 0.5, mb: 1.5, color: "text.secondary" }}>
+                {memberActionDialog.memberName || "Selected member"}
+              </Typography>
+
+              {(memberActionDialog.type === "approve" || memberActionDialog.type === "changeRole") && (
+                <FormControl fullWidth size="small" sx={{ mb: 2 }}>
+                  <InputLabel id="member-role-label">Role</InputLabel>
+                  <Select
+                    labelId="member-role-label"
+                    label="Role"
+                    value={memberActionDialog.selectedRole}
+                    onChange={(e) =>
+                      setMemberActionDialog((prev) => ({
+                        ...prev,
+                        selectedRole: e.target.value as "reader" | "editor",
+                      }))
+                    }
+                  >
+                    <MenuItem value="reader">Reader</MenuItem>
+                    <MenuItem value="editor">Editor</MenuItem>
+                  </Select>
+                </FormControl>
+              )}
+
+              <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
+                <Button
+                  variant="outlined"
+                  onClick={closeMemberActionDialog}
+                  size="small"
+                  sx={{
+                    borderColor: Colors.main,
+                    color: Colors.main,
+                    textTransform: "none",
+                    fontWeight: 600,
+                    "&:hover": {
+                      borderColor: Colors.main,
+                      backgroundColor: "rgba(35,48,68,0.06)",
+                    },
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="contained"
+                  onClick={submitMemberActionDialog}
+                  size="small"
+                  sx={{
+                    backgroundColor: Colors.main,
+                    color: "#fff",
+                    textTransform: "none",
+                    fontWeight: 700,
+                    px: 2.25,
+                    "&:hover": { backgroundColor: Colors.main, opacity: 0.95 },
+                  }}
+                >
+                  Confirm
+                </Button>
+              </Box>
+            </Box>
+          )}
+
           {memberModalTab === "members" && (
             <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: 430 }}>
               <Table stickyHeader size="small">
@@ -1096,7 +1217,7 @@ const handleApplyNodeRed = async (groupId: string) => {
                     <TableCell sx={{ fontWeight: 700, backgroundColor: "background.default" }}>Name</TableCell>
                     <TableCell sx={{ fontWeight: 700, backgroundColor: "background.default" }}>Email</TableCell>
                     <TableCell sx={{ fontWeight: 700, backgroundColor: "background.default" }}>Role</TableCell>
-                    <TableCell sx={{ fontWeight: 700, textAlign: "center", backgroundColor: "background.default" }}>Action</TableCell>
+                    <TableCell sx={{ fontWeight: 700, textAlign: "center", backgroundColor: "background.default" }}>Actions</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -1114,13 +1235,27 @@ const handleApplyNodeRed = async (groupId: string) => {
                           />
                         </TableCell>
                         <TableCell sx={{ textAlign: "center" }}>
-                          <IconButton
-                            color="error"
-                            size="small"
-                            onClick={() => handleLeaveGroup(memberModalGroup?.id, member.email, true)}
-                          >
-                            <RemoveCircleIcon />
-                          </IconButton>
+                          <Tooltip title="Change Role">
+                            <span>
+                              <IconButton
+                                color="primary"
+                                size="small"
+                                disabled={!memberModalGroup?.is_owner}
+                                onClick={() => openMemberActionDialog("changeRole", member)}
+                              >
+                                <EditOutlinedIcon fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                          <Tooltip title="Remove Member">
+                            <IconButton
+                              color="error"
+                              size="small"
+                              onClick={() => handleLeaveGroup(memberModalGroup?.id, member.email, true)}
+                            >
+                              <PersonRemoveAlt1Icon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
                         </TableCell>
                       </TableRow>
                     ))
@@ -1153,20 +1288,20 @@ const handleApplyNodeRed = async (groupId: string) => {
                         <TableCell>{`${member.first_name} ${member.last_name}`}</TableCell>
                         <TableCell>{member.email}</TableCell>
                         <TableCell sx={{ textAlign: "center" }}>
-                          <IconButton
-                            color="success"
-                            size="small"
-                            onClick={() => handleAction("approve", member?.membership_id)}
-                          >
-                            <CheckCircleIcon />
-                          </IconButton>
-                          <IconButton
-                            color="error"
-                            size="small"
-                            onClick={() => handleAction("reject", member?.membership_id)}
-                          >
-                            <CancelIcon />
-                          </IconButton>
+                        <IconButton
+                          color="success"
+                          size="small"
+                          onClick={() => openMemberActionDialog("approve", member)}
+                        >
+                          <CheckCircleIcon />
+                        </IconButton>
+                        <IconButton
+                          color="error"
+                          size="small"
+                          onClick={() => openMemberActionDialog("reject", member)}
+                        >
+                          <CancelIcon />
+                        </IconButton>
                         </TableCell>
                       </TableRow>
                     ))

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -1224,24 +1224,38 @@ const handleApplyNodeRed = async (groupId: string) => {
                   {approvedMembers.length > 0 ? (
                     approvedMembers.map((member: any, index: any) => (
                       <TableRow key={index} hover>
-                        <TableCell>{`${member?.first_name} ${member?.last_name}`}</TableCell>
-                        <TableCell>{member?.email}</TableCell>
+                        <TableCell sx={{ py: 1.2 }}>{`${member?.first_name} ${member?.last_name}`}</TableCell>
+                        <TableCell sx={{ py: 1.2 }}>{member?.email}</TableCell>
                         <TableCell>
                           <Chip
-                            label={member?.role || "reader"}
+                            label={(member?.role || "reader").toUpperCase()}
                             size="small"
                             color={member?.role === "editor" ? "secondary" : "primary"}
-                            variant={member?.role === "editor" ? "filled" : "outlined"}
+                            variant="filled"
+                            sx={
+                              member?.role === "editor"
+                                ? {}
+                                : {
+                                    backgroundColor: Colors.main,
+                                    color: "#fff",
+                                  }
+                            }
                           />
                         </TableCell>
                         <TableCell sx={{ textAlign: "center" }}>
                           <Tooltip title="Change Role">
                             <span>
                               <IconButton
-                                color="primary"
+                                color="inherit"
                                 size="small"
                                 disabled={!memberModalGroup?.is_owner}
                                 onClick={() => openMemberActionDialog("changeRole", member)}
+                                sx={{
+                                  backgroundColor: Colors.main,
+                                  color: "#fff",
+                                  mr: 0.75,
+                                  "&:hover": { backgroundColor: Colors.main, opacity: 0.92 },
+                                }}
                               >
                                 <EditOutlinedIcon fontSize="small" />
                               </IconButton>
@@ -1249,9 +1263,14 @@ const handleApplyNodeRed = async (groupId: string) => {
                           </Tooltip>
                           <Tooltip title="Remove Member">
                             <IconButton
-                              color="error"
+                              color="inherit"
                               size="small"
                               onClick={() => handleLeaveGroup(memberModalGroup?.id, member.email, true)}
+                              sx={{
+                                backgroundColor: "error.main",
+                                color: "#fff",
+                                "&:hover": { backgroundColor: "error.main", opacity: 0.92 },
+                              }}
                             >
                               <PersonRemoveAlt1Icon fontSize="small" />
                             </IconButton>
@@ -1285,23 +1304,38 @@ const handleApplyNodeRed = async (groupId: string) => {
                   {pendingMembers.length > 0 ? (
                     pendingMembers.map((member: any, index: any) => (
                       <TableRow key={index} hover>
-                        <TableCell>{`${member.first_name} ${member.last_name}`}</TableCell>
-                        <TableCell>{member.email}</TableCell>
+                        <TableCell sx={{ py: 1.2 }}>{`${member.first_name} ${member.last_name}`}</TableCell>
+                        <TableCell sx={{ py: 1.2 }}>{member.email}</TableCell>
                         <TableCell sx={{ textAlign: "center" }}>
-                        <IconButton
-                          color="success"
-                          size="small"
-                          onClick={() => openMemberActionDialog("approve", member)}
-                        >
-                          <CheckCircleIcon />
-                        </IconButton>
-                        <IconButton
-                          color="error"
-                          size="small"
-                          onClick={() => openMemberActionDialog("reject", member)}
-                        >
-                          <CancelIcon />
-                        </IconButton>
+                          <Tooltip title="Approve Request">
+                            <IconButton
+                              color="inherit"
+                              size="small"
+                              onClick={() => openMemberActionDialog("approve", member)}
+                              sx={{
+                                backgroundColor: "success.main",
+                                color: "#fff",
+                                mr: 0.75,
+                                "&:hover": { backgroundColor: "success.main", opacity: 0.92 },
+                              }}
+                            >
+                              <CheckCircleIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title="Reject Request">
+                            <IconButton
+                              color="inherit"
+                              size="small"
+                              onClick={() => openMemberActionDialog("reject", member)}
+                              sx={{
+                                backgroundColor: "error.main",
+                                color: "#fff",
+                                "&:hover": { backgroundColor: "error.main", opacity: 0.92 },
+                              }}
+                            >
+                              <CancelIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
                         </TableCell>
                       </TableRow>
                     ))

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -84,11 +84,12 @@ export default function ListClients() {
   const [memberModalTab, setMemberModalTab] = useState<"members" | "pending">("members");
   const [memberActionDialog, setMemberActionDialog] = useState<{
     open: boolean;
-    type: "approve" | "reject" | "changeRole";
+    type: "approve" | "reject" | "changeRole" | "removeMember";
     membershipId?: any;
     userId?: any;
     serviceId?: any;
     memberName?: string;
+    memberEmail?: string;
     currentRole?: "reader" | "editor";
     selectedRole: "reader" | "editor";
   }>({
@@ -102,7 +103,6 @@ export default function ListClients() {
 
   const [isCreatingProject, setIsCreatingProject] = useState(false);
   const dispatch = useAppDispatch();
-
 
 
   const message = searchParams.get("message");
@@ -342,7 +342,7 @@ export default function ListClients() {
   };
 
   const openMemberActionDialog = (
-    type: "approve" | "reject" | "changeRole",
+    type: "approve" | "reject" | "changeRole" | "removeMember",
     member: any
   ) => {
     const memberName = `${member?.first_name || ""} ${member?.last_name || ""}`.trim();
@@ -363,6 +363,7 @@ export default function ListClients() {
       userId: memberUserId,
       serviceId,
       memberName,
+      memberEmail: member?.email,
       currentRole,
       selectedRole: type === "changeRole" ? currentRole : "reader",
     });
@@ -379,7 +380,12 @@ export default function ListClients() {
       toast.error("Authentication token not found.");
       return;
     }
-    if (!memberActionDialog.membershipId) {
+    if (
+      (memberActionDialog.type === "approve" ||
+        memberActionDialog.type === "reject" ||
+        memberActionDialog.type === "changeRole") &&
+      !memberActionDialog.membershipId
+    ) {
       toast.error("Membership ID is missing.");
       return;
     }
@@ -423,6 +429,21 @@ export default function ListClients() {
           { headers: { Authorization: `Bearer ${token}` } }
         );
         toast.success("Member role updated successfully.");
+      }
+      if (memberActionDialog.type === "removeMember") {
+        if (!memberActionDialog.serviceId || !memberActionDialog.memberEmail) {
+          toast.error("Missing group_id or user email for remove action.");
+          return;
+        }
+        const response = await axios.post(
+          `${process.env.REACT_APP_BACKEND_URL}/leave_group`,
+          {
+            user_email: memberActionDialog.memberEmail,
+            group_id: memberActionDialog.serviceId,
+          },
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        toast.success(response?.data?.message || "Member removed successfully.");
       }
 
       closeMemberActionDialog();
@@ -1170,10 +1191,16 @@ const handleApplyNodeRed = async (groupId: string) => {
                 {memberActionDialog.type === "approve" && "Approve Request"}
                 {memberActionDialog.type === "reject" && "Reject Request"}
                 {memberActionDialog.type === "changeRole" && "Change Member Role"}
+                {memberActionDialog.type === "removeMember" && "Remove Member"}
               </Typography>
               <Typography variant="body2" sx={{ mt: 0.5, mb: 1.5, color: "text.secondary" }}>
                 {memberActionDialog.memberName || "Selected member"}
               </Typography>
+              {memberActionDialog.type === "removeMember" && (
+                <Typography variant="body2" sx={{ mb: 1.5, color: "error.main", fontWeight: 600 }}>
+                  This will remove the member from this project.
+                </Typography>
+              )}
 
               {(memberActionDialog.type === "approve" || memberActionDialog.type === "changeRole") && (
                 <FormControl fullWidth size="small" sx={{ mb: 2 }}>
@@ -1288,18 +1315,21 @@ const handleApplyNodeRed = async (groupId: string) => {
                             </span>
                           </Tooltip>
                           <Tooltip title="Remove Member">
-                            <IconButton
-                              color="inherit"
-                              size="small"
-                              onClick={() => handleLeaveGroup(memberModalGroup?.id, member.email, true)}
-                              sx={{
-                                backgroundColor: "error.main",
-                                color: "#fff",
-                                "&:hover": { backgroundColor: "error.main", opacity: 0.92 },
-                              }}
-                            >
-                              <PersonRemoveAlt1Icon fontSize="small" />
-                            </IconButton>
+                            <span>
+                              <IconButton
+                                color="inherit"
+                                size="small"
+                                disabled={!memberModalGroup?.is_owner}
+                                onClick={() => openMemberActionDialog("removeMember", member)}
+                                sx={{
+                                  backgroundColor: "error.main",
+                                  color: "#fff",
+                                  "&:hover": { backgroundColor: "error.main", opacity: 0.92 },
+                                }}
+                              >
+                                <PersonRemoveAlt1Icon fontSize="small" />
+                              </IconButton>
+                            </span>
                           </Tooltip>
                         </TableCell>
                       </TableRow>

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -36,6 +36,7 @@ import {
   FormControl,
   InputLabel,
   Select
+  , Alert
 } from "@mui/material";
 import axios, { AxiosError } from "axios";
 import { useLocation } from "react-router-dom";
@@ -102,7 +103,19 @@ export default function ListClients() {
   const [nodeRedTargetGroup, setNodeRedTargetGroup] = useState<any>(null);
 
   const [isCreatingProject, setIsCreatingProject] = useState(false);
+  const [groupSearchFeedback, setGroupSearchFeedback] = useState<{
+    severity: "success" | "info" | "warning" | "error";
+    message: string;
+  } | null>(null);
   const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (!groupSearchFeedback) return;
+    const timer = setTimeout(() => {
+      setGroupSearchFeedback(null);
+    }, 4000);
+    return () => clearTimeout(timer);
+  }, [groupSearchFeedback]);
 
 
   const message = searchParams.get("message");
@@ -261,6 +274,7 @@ export default function ListClients() {
       toast.error("Group ID is required.");
       return;
     }
+    setGroupSearchFeedback(null);
 
     try {
       const token = keycloak?.token;
@@ -288,36 +302,30 @@ export default function ListClients() {
       // Check if the response is an array (user is not a member and can join)
       if (Array.isArray(groupData)) {
         setJoinNewGroups(groupData);
-
-        Swal.fire({
-          icon: "success",
-          title: "Success!",
-          text: "Project details fetched successfully.",
-          confirmButtonColor: "#3085d6",
+        setGroupSearchFeedback({
+          severity: "success",
+          message: "Project details fetched successfully.",
         });
       }
       // Check if response is an object with status (user is already a member or owner)
       else if (groupData?.status === "owner") {
-        Swal.fire({
-          icon: "info",
-          title: "Info",
-          text: "You are already the owner of this project.",
-          confirmButtonColor: "#3085d6",
+        setJoinNewGroups([]);
+        setGroupSearchFeedback({
+          severity: "info",
+          message: "You are already the owner of this project.",
         });
       } else if (groupData?.status === "member") {
-        Swal.fire({
-          icon: "info",
-          title: "Info",
-          text: "You are already a member of this project.",
-          confirmButtonColor: "#3085d6",
+        setJoinNewGroups([]);
+        setGroupSearchFeedback({
+          severity: "info",
+          message: "You are already a member of this project.",
         });
       } else {
         // Handle unexpected response formats
-        Swal.fire({
-          icon: "warning",
-          title: "Warning",
-          text: "Unexpected response received.",
-          confirmButtonColor: "#f39c12",
+        setJoinNewGroups([]);
+        setGroupSearchFeedback({
+          severity: "warning",
+          message: "Unexpected response received.",
         });
       }
     } catch (error: any) {
@@ -331,12 +339,10 @@ export default function ListClients() {
       }
 
       toast.error(errorMessage);
-
-      Swal.fire({
-        icon: "error",
-        title: "Error",
-        text: errorMessage,
-        confirmButtonColor: "#d33",
+      setJoinNewGroups([]);
+      setGroupSearchFeedback({
+        severity: "error",
+        message: errorMessage,
       });
     }
   };
@@ -532,11 +538,7 @@ const handleApplyNodeRed = async (groupId: string) => {
 
   const joinGroup = async (group_id: any) => {
     if (!group_id) {
-      Swal.fire({
-        icon: "warning",
-        title: "Invalid Group",
-        text: "Please select a valid project to join.",
-      });
+      toast.warning("Please select a valid project to join.");
       return;
     }
 
@@ -549,18 +551,19 @@ const handleApplyNodeRed = async (groupId: string) => {
         `${process.env.REACT_APP_BACKEND_URL}/join_group`,
         data
       );
-      Swal.fire({
-        icon: "success",
-        title: "Join Request Sent",
-        text: response?.data?.message || "Your request to join the project was successful!",
+      toast.success(response?.data?.message || "Your request to join the project was successful.");
+      setGroupSearchFeedback({
+        severity: "success",
+        message: "Join request sent successfully.",
       });
       getAllGroups();
     } catch (error: any) {
       console.error("Error joining group:", error);
-      Swal.fire({
-        icon: "error",
-        title: "Error",
-        text: error.response?.data?.message || "Failed to join the project. Please try again later.",
+      const message = error.response?.data?.message || "Failed to join the project. Please try again later.";
+      toast.error(message);
+      setGroupSearchFeedback({
+        severity: "error",
+        message,
       });
     }
   };
@@ -1026,6 +1029,20 @@ const handleApplyNodeRed = async (groupId: string) => {
                     </Grid>
                   </Grid>
                 </Box>
+                {groupSearchFeedback && (
+                  <Alert
+                    severity={groupSearchFeedback.severity}
+                    sx={{
+                      mt: 2,
+                      mb: 1,
+                      borderRadius: 1.5,
+                      border: "1px solid",
+                      borderColor: "divider",
+                    }}
+                  >
+                    {groupSearchFeedback.message}
+                  </Alert>
+                )}
 
                 {joinNewGroups?.length > 0 && (
                   <TableContainer component={Paper} sx={{ maxHeight: "70vh", overflowY: "auto" }}>

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -1115,6 +1115,7 @@ const handleApplyNodeRed = async (groupId: string) => {
             backgroundColor: "background.paper",
             color: "text.primary",
             borderRadius: 2,
+            maxHeight: "85vh",
           },
         }}
       >
@@ -1137,7 +1138,13 @@ const handleApplyNodeRed = async (groupId: string) => {
             <CloseIcon />
           </IconButton>
         </DialogTitle>
-        <DialogContent dividers sx={{ px: 3, py: 2 }}>
+        <DialogContent
+          dividers
+          sx={{
+            px: 3,
+            py: 2,
+            overflowY: "auto",
+          }}>
           <Box
             sx={(theme) => ({
               mb: 2,
@@ -1280,7 +1287,13 @@ const handleApplyNodeRed = async (groupId: string) => {
           )}
 
           {memberModalTab === "members" && (
-            <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: 430 }}>
+            <TableContainer
+              component={Paper}
+              variant="outlined"
+              sx={{
+                height: 430,
+                overflowY: "auto",
+              }}>
               <Table stickyHeader size="small">
                 <TableHead>
                   <TableRow>
@@ -1364,7 +1377,13 @@ const handleApplyNodeRed = async (groupId: string) => {
           )}
 
           {memberModalTab === "pending" && (
-            <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: 430 }}>
+            <TableContainer
+              component={Paper}
+              variant="outlined"
+              sx={{
+                height: 430,
+                overflowY: "auto",
+              }}>
               <Table stickyHeader size="small">
                 <TableHead>
                   <TableRow>
@@ -1447,3 +1466,5 @@ const handleApplyNodeRed = async (groupId: string) => {
     </Dashboard>
   );
 }
+
+

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -1,7 +1,7 @@
 import LinkCustom from "../components/LinkCustom";
 import { ToastContainer, toast } from "react-toastify";
 import { useKeycloak } from "@react-keycloak/web";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Dashboard from "../components/DashboardComponent";
 
 import {
@@ -22,17 +22,17 @@ import {
   TableRow,
   TextField,
   Typography,
-  Popover,
-  List,
-  ListItem,
-  ListItemText,
-  Divider,
-  ClickAwayListener,
   CircularProgress,
   FormControlLabel,
   Switch,
   Menu,
-  MenuItem
+  MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Tabs,
+  Tab,
+  Chip
 } from "@mui/material";
 import axios, { AxiosError } from "axios";
 import { useLocation } from "react-router-dom";
@@ -53,6 +53,7 @@ import * as Yup from "yup";
 import { setSelectedGroupId } from "../store/rolesSlice";
 import { useAppDispatch } from "../hooks/hooks";
 import { Settings } from "@mui/icons-material";
+import { Colors } from "../styles/Colors";
 
 
 interface Group {
@@ -76,12 +77,8 @@ export default function ListClients() {
   const [joinNewGroups, setJoinNewGroups] = useState<any[]>([]);
   const [myGroups, setMyGroups] = useState<any[]>([]);
   const [anchorEl, setAnchorEl] = useState(null);
-  const [pendingRequests, setPendingRequests] = useState([]);
-  const [anchorElPending, setAnchorElPending] = useState(null);
-  const [selectedMembers, setSelectedMembers] = useState([]);
-  const [openPendingGroupId, setOpenPendingGroupId] = useState<number | null>(null);
-  const [pendingPopover, setPendingPopover] = useState<{ anchorEl: HTMLElement | null, groupId: number | null }>({ anchorEl: null, groupId: null });
-  const [membersPopover, setMembersPopover] = useState<{ anchorEl: HTMLElement | null, groupId: number | null }>({ anchorEl: null, groupId: null });
+  const [memberModalGroup, setMemberModalGroup] = useState<any | null>(null);
+  const [memberModalTab, setMemberModalTab] = useState<"members" | "pending">("members");
   const [nodeRedMenuAnchor, setNodeRedMenuAnchor] = useState<null | HTMLElement>(null);
   const [nodeRedTargetGroup, setNodeRedTargetGroup] = useState<any>(null);
 
@@ -90,8 +87,6 @@ export default function ListClients() {
 
 
 
-  const popoverRef = useRef(null); // ✅ Store popover anchor in a ref
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const message = searchParams.get("message");
   const validationSchema = Yup.object({
     searchQuery: Yup.string()
@@ -328,53 +323,76 @@ export default function ListClients() {
     }
   };
 
-  const handleAction = (action: string, userId: any) => {
-    let data = { "membership_id": userId, "action": action } 
-      const token = keycloak?.token;
-    Swal.fire({
+  const handleAction = async (action: string, userId: any) => {
+    const isApproveAction = action === "approve";
+    const token = keycloak?.token;
+
+    const confirmation = await Swal.fire({
       title: `Are you sure you want to ${action} this request?`,
       icon: "warning",
       showCancelButton: true,
       confirmButtonText: "Yes",
       cancelButtonText: "No",
-    }).then(async (result) => {
-      if (result.isConfirmed) {
-        try {
-          const response = await axios.post(
-            `${process.env.REACT_APP_BACKEND_URL}/manage_membership`,
-            data,
-            { headers: { Authorization: `Bearer ${token}` } }
-          );
-          Swal.fire("Success", response.data.message, "success");
-          getAllGroups();
-        } catch (error: any) {
-          Swal.fire(
-            "Error",
-            error?.response?.data?.message || "An error occurred.",
-            "error"
-          );
-        }
-      }
+      input: isApproveAction ? "select" : undefined,
+      inputValue: isApproveAction ? "reader" : undefined,
+      inputOptions: isApproveAction
+        ? { reader: "Reader", editor: "Editor" }
+        : undefined,
+      inputPlaceholder: isApproveAction ? "Select role" : undefined,
+      inputValidator: isApproveAction
+        ? (value: string) => {
+            if (!value || !["reader", "editor"].includes(value)) {
+              return "Please select a valid role.";
+            }
+            return null;
+          }
+        : undefined,
     });
+
+    if (!confirmation.isConfirmed) return;
+
+    const selectedRole = isApproveAction ? confirmation.value : undefined;
+    if (isApproveAction && !["reader", "editor"].includes(selectedRole)) {
+      Swal.fire("Validation Error", "Selected role is invalid.", "error");
+      return;
+    }
+
+    const data = {
+      membership_id: userId,
+      action,
+      ...(isApproveAction ? { role: selectedRole } : {}),
+    };
+
+    try {
+      const response = await axios.post(
+        `${process.env.REACT_APP_BACKEND_URL}/manage_membership`,
+        data,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      Swal.fire("Success", response.data.message, "success");
+      getAllGroups();
+    } catch (error: any) {
+      Swal.fire(
+        "Error",
+        error?.response?.data?.message ||
+          "Failed to update membership. Please verify role and membership status.",
+        "error"
+      );
+    }
   };
-  const handleViewMembers = (event: React.MouseEvent<HTMLElement>, groupId: number) => {
-    setMembersPopover({ anchorEl: event.currentTarget, groupId });
+  const openMemberModal = (group: any, tab: "members" | "pending") => {
+    setMemberModalGroup(group);
+    setMemberModalTab(tab);
   };
 
-  const handleCloseMembersPopover = () => {
-    setMembersPopover({ anchorEl: null, groupId: null });
+  const closeMemberModal = () => {
+    setMemberModalGroup(null);
+    setMemberModalTab("members");
   };
-  const handleOpenPendingPopover = (event: React.MouseEvent<HTMLElement>, groupId: number) => {
-    setPendingPopover({ anchorEl: event.currentTarget, groupId }); // Attach popover to clicked element
-    setOpenPendingGroupId(groupId);  // Track which group's popover is open
-  };
-
-
-  const handleClosePendingPopover = () => {
-    console.log("Close button clicked");
-    setPendingPopover({ anchorEl: null, groupId: null }); // New object ensures state updates
-    setOpenPendingGroupId(null); // Also reset open group tracking
-  };
+  const approvedMembers =
+    memberModalGroup?.members?.filter((x: any) => x?.membership_status === "approved") || [];
+  const pendingMembers =
+    memberModalGroup?.members?.filter((x: any) => x?.membership_status === "pending") || [];
 
   const handleNodeRedMenuOpen = (
     event: React.MouseEvent<HTMLElement>,
@@ -686,91 +704,14 @@ const handleApplyNodeRed = async (groupId: string) => {
                                 }}
                               >
                                 {/* View Members */}
-                                <IconButton disabled={!group?.is_owner} color="primary" onClick={(e) => handleViewMembers(e, group?.id)}>
+                                <IconButton disabled={!group?.is_owner} color="primary" onClick={() => openMemberModal(group, "members")}>
                                   <GroupIcon />
                                 </IconButton>
-                                {membersPopover.groupId === group?.id && (
-                                  <Popover
-                                    open={Boolean(membersPopover.anchorEl)}
-                                    anchorEl={membersPopover.anchorEl}
-                                    onClose={handleCloseMembersPopover}
-                                    anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                                    transformOrigin={{ vertical: "top", horizontal: "left" }}
-                                  >
-                                    <ClickAwayListener onClickAway={handleCloseMembersPopover}>
-                                      <Box sx={{ padding: 1, minWidth: 250, maxHeight: 300, overflowY: "auto" }}>
-                                        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: 1 }}>
-                                          <Typography variant="subtitle1">Members</Typography>
-                                          <IconButton size="small" onClick={handleCloseMembersPopover}>
-                                            <CloseIcon />
-                                          </IconButton>
-                                        </Box>
-                                        <Divider />
-                                        <List>
-                                          {group?.members?.some((x: any) => x?.membership_status === "approved") ? (
-                                            group?.members
-                                              .filter((x: any) => x?.membership_status === "approved")
-                                              .map((member: any, index: any) => (
-                                                <ListItem key={index} sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                                                  <ListItemText primary={`${member?.first_name} ${member?.last_name}`} secondary={member?.email} />
-                                                  <IconButton color="error" size="small" onClick={() => handleLeaveGroup(group?.id, member.email, true)}>
-                                                    <RemoveCircleIcon />
-                                                  </IconButton>
-                                                </ListItem>
-                                              ))
-                                          ) : (
-                                            <Typography sx={{ padding: 1 }}>No approved members found.</Typography>
-                                          )}
-                                        </List>
-                                      </Box>
-                                    </ClickAwayListener>
-                                  </Popover>
-                                )}
 
                                 {/* View Pending Requests */}
-                                <IconButton color="warning" disabled={!group?.is_owner} onClick={(e) => handleOpenPendingPopover(e, group?.id)}>
+                                <IconButton color="warning" disabled={!group?.is_owner} onClick={() => openMemberModal(group, "pending")}>
                                   <HourglassEmptyIcon />
                                 </IconButton>
-                                {openPendingGroupId === group?.id && (
-                                  <Popover
-                                    open={Boolean(pendingPopover.anchorEl)}
-                                    anchorEl={pendingPopover.anchorEl}
-                                    onClose={handleClosePendingPopover}
-                                    anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                                    transformOrigin={{ vertical: "top", horizontal: "left" }}
-                                  >
-                                    <ClickAwayListener onClickAway={handleClosePendingPopover}>
-                                      <Box sx={{ padding: 1, minWidth: 250, maxHeight: 300, overflowY: "auto" }}>
-                                        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: 1 }}>
-                                          <Typography variant="subtitle1">Pending Requests</Typography>
-                                          <IconButton size="small" onClick={handleClosePendingPopover}>
-                                            <CloseIcon />
-                                          </IconButton>
-                                        </Box>
-                                        <Divider />
-                                        <List>
-                                          {group?.members?.some((x: any) => x?.membership_status === "pending") ? (
-                                            group?.members
-                                              .filter((x: any) => x?.membership_status === "pending")
-                                              .map((member: any, index: any) => (
-                                                <ListItem key={index} sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                                                  <ListItemText primary={`${member.first_name} ${member.last_name}`} secondary={member.email} />
-                                                  <IconButton color="success" size="small" onClick={() => handleAction("approve", member?.membership_id)}>
-                                                    <CheckCircleIcon />
-                                                  </IconButton>
-                                                  <IconButton color="error" size="small" onClick={() => handleAction("reject", member?.membership_id)}>
-                                                    <CancelIcon />
-                                                  </IconButton>
-                                                </ListItem>
-                                              ))
-                                          ) : (
-                                            <Typography sx={{ padding: 1 }}>No pending requests.</Typography>
-                                          )}
-                                        </List>
-                                      </Box>
-                                    </ClickAwayListener>
-                                  </Popover>
-                                )}
 
                                 {/* Leave Group */}
                                 <IconButton color="error" disabled={group?.is_owner} onClick={() => handleLeaveGroup(group?.id, userInfo?.email, false)}>
@@ -1060,6 +1001,188 @@ const handleApplyNodeRed = async (groupId: string) => {
           </Box>
         </>
       )}
+      <Dialog
+        open={Boolean(memberModalGroup)}
+        onClose={(_, reason) => {
+          if (reason === "backdropClick" || reason === "escapeKeyDown") return;
+          closeMemberModal();
+        }}
+        disableEscapeKeyDown
+        fullWidth
+        maxWidth="md"
+        PaperProps={{
+          sx: {
+            backgroundColor: "background.paper",
+            color: "text.primary",
+            borderRadius: 2,
+          },
+        }}
+      >
+        <DialogTitle
+          sx={(theme) => ({
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            borderBottom: `1px solid ${theme.palette.divider}`,
+            pb: 1.5
+          })}
+        >
+          <Box>
+            <Typography variant="h6" sx={{ fontWeight: 700 }}>Project Authorization</Typography>
+            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+              Manage approved members and pending access requests
+            </Typography>
+          </Box>
+          <IconButton size="small" onClick={closeMemberModal}>
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers sx={{ px: 3, py: 2 }}>
+          <Box
+            sx={(theme) => ({
+              mb: 2,
+              px: 1.5,
+              py: 1.25,
+              border: `1px solid ${theme.palette.divider}`,
+              borderRadius: 1,
+              borderLeft: `5px solid ${Colors.main}`,
+              backgroundColor:
+                theme.palette.mode === "dark"
+                  ? "rgba(255,255,255,0.03)"
+                  : "background.default",
+            })}
+          >
+            <Typography variant="subtitle1" sx={{ fontWeight: 700, lineHeight: 1.2 }}>
+              {memberModalGroup?.name || "Project"}
+            </Typography>
+            <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+              Manage approved members and pending access requests for this project.
+            </Typography>
+            <Typography variant="caption" sx={{ color: "text.secondary", display: "block", mt: 0.5 }}>
+              Group ID: {memberModalGroup?.keycloak_group_id || "-"}
+            </Typography>
+          </Box>
+          <Tabs
+            value={memberModalTab}
+            onChange={(_, newTab) => setMemberModalTab(newTab)}
+            sx={(theme) => ({
+              mb: 2,
+              borderBottom: `1px solid ${theme.palette.divider}`,
+              "& .MuiTab-root": {
+                textTransform: "none",
+                fontWeight: 600,
+                color:
+                  theme.palette.mode === "dark"
+                    ? "rgba(255,255,255,0.75)"
+                    : `${Colors.main}B3`,
+              },
+              "& .Mui-selected": {
+                color: Colors.main,
+              },
+              "& .MuiTabs-indicator": {
+                backgroundColor: Colors.main,
+              },
+            })}
+          >
+            <Tab label={`Approved Members (${approvedMembers.length})`} value="members" />
+            <Tab label={`Pending Requests (${pendingMembers.length})`} value="pending" />
+          </Tabs>
+
+          {memberModalTab === "members" && (
+            <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: 430 }}>
+              <Table stickyHeader size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ fontWeight: 700, backgroundColor: "background.default" }}>Name</TableCell>
+                    <TableCell sx={{ fontWeight: 700, backgroundColor: "background.default" }}>Email</TableCell>
+                    <TableCell sx={{ fontWeight: 700, backgroundColor: "background.default" }}>Role</TableCell>
+                    <TableCell sx={{ fontWeight: 700, textAlign: "center", backgroundColor: "background.default" }}>Action</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {approvedMembers.length > 0 ? (
+                    approvedMembers.map((member: any, index: any) => (
+                      <TableRow key={index} hover>
+                        <TableCell>{`${member?.first_name} ${member?.last_name}`}</TableCell>
+                        <TableCell>{member?.email}</TableCell>
+                        <TableCell>
+                          <Chip
+                            label={member?.role || "reader"}
+                            size="small"
+                            color={member?.role === "editor" ? "secondary" : "primary"}
+                            variant={member?.role === "editor" ? "filled" : "outlined"}
+                          />
+                        </TableCell>
+                        <TableCell sx={{ textAlign: "center" }}>
+                          <IconButton
+                            color="error"
+                            size="small"
+                            onClick={() => handleLeaveGroup(memberModalGroup?.id, member.email, true)}
+                          >
+                            <RemoveCircleIcon />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell colSpan={4} sx={{ py: 4, textAlign: "center", color: "text.secondary" }}>
+                        No approved members found.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+
+          {memberModalTab === "pending" && (
+            <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: 430 }}>
+              <Table stickyHeader size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ fontWeight: 700, backgroundColor: "background.default" }}>Name</TableCell>
+                    <TableCell sx={{ fontWeight: 700, backgroundColor: "background.default" }}>Email</TableCell>
+                    <TableCell sx={{ fontWeight: 700, textAlign: "center", backgroundColor: "background.default" }}>Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {pendingMembers.length > 0 ? (
+                    pendingMembers.map((member: any, index: any) => (
+                      <TableRow key={index} hover>
+                        <TableCell>{`${member.first_name} ${member.last_name}`}</TableCell>
+                        <TableCell>{member.email}</TableCell>
+                        <TableCell sx={{ textAlign: "center" }}>
+                          <IconButton
+                            color="success"
+                            size="small"
+                            onClick={() => handleAction("approve", member?.membership_id)}
+                          >
+                            <CheckCircleIcon />
+                          </IconButton>
+                          <IconButton
+                            color="error"
+                            size="small"
+                            onClick={() => handleAction("reject", member?.membership_id)}
+                          >
+                            <CancelIcon />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  ) : (
+                    <TableRow>
+                      <TableCell colSpan={3} sx={{ py: 4, textAlign: "center", color: "text.secondary" }}>
+                        No pending requests.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </DialogContent>
+      </Dialog>
       {isCreatingProject || loading && (
         <Box
           sx={{

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -107,6 +107,7 @@ export default function ListClients() {
     severity: "success" | "info" | "warning" | "error";
     message: string;
   } | null>(null);
+  const [nodeRedToggleFeedback, setNodeRedToggleFeedback] = useState<string | null>(null);
   const dispatch = useAppDispatch();
 
   useEffect(() => {
@@ -116,6 +117,14 @@ export default function ListClients() {
     }, 4000);
     return () => clearTimeout(timer);
   }, [groupSearchFeedback]);
+
+  useEffect(() => {
+    if (!nodeRedToggleFeedback) return;
+    const timer = setTimeout(() => {
+      setNodeRedToggleFeedback(null);
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [nodeRedToggleFeedback]);
 
 
   const message = searchParams.get("message");
@@ -149,6 +158,7 @@ export default function ListClients() {
         .required("Project description is required"),
     }),
     onSubmit: async (values, { resetForm }) => {
+      setNodeRedToggleFeedback(null);
       const token = keycloak?.token;
       if (!token) {
         Swal.fire("Error", "Authentication token not found. Please log in.", "error");
@@ -919,6 +929,19 @@ const handleApplyNodeRed = async (groupId: string) => {
               </AccordionSummary>
               <AccordionDetails>
                 <Box component="form" onSubmit={formikCreateProject.handleSubmit} sx={{ width: "100%" }}>
+                  {nodeRedToggleFeedback && (
+                    <Alert
+                      severity="info"
+                      sx={{
+                        mb: 2,
+                        borderRadius: 1.5,
+                        border: "1px solid",
+                        borderColor: "divider",
+                      }}
+                    >
+                      {nodeRedToggleFeedback}
+                    </Alert>
+                  )}
                   <Grid container spacing={2}>
                     <Grid item xs={12} sm={6}>
                       <TextField
@@ -959,19 +982,11 @@ const handleApplyNodeRed = async (groupId: string) => {
                             onChange={(e) => {
                               const checked = e.target.checked;
                               formikCreateProject.setFieldValue("includeNodeRed", checked);
-
-                              Swal.fire({
-                                icon: "info",
-                                title: "Node-RED Toggle",
-                                text: checked
+                              setNodeRedToggleFeedback(
+                                checked
                                   ? "Node-RED will be included in this project."
-                                  : "Node-RED will not be included in this project.",
-                                timer: 2500,
-                                showConfirmButton: false,
-                                position: "bottom-end",
-                                toast: true,
-
-                              });
+                                  : "Node-RED will not be included in this project."
+                              );
                             }}
                           />
                         }

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -347,12 +347,17 @@ export default function ListClients() {
     }
   };
 
+  const normalizeMemberRole = (roleValue: any): "reader" | "editor" => {
+    const normalized = String(roleValue || "").trim().toLowerCase();
+    return normalized === "editor" || normalized === "editors" ? "editor" : "reader";
+  };
+
   const openMemberActionDialog = (
     type: "approve" | "reject" | "changeRole" | "removeMember",
     member: any
   ) => {
     const memberName = `${member?.first_name || ""} ${member?.last_name || ""}`.trim();
-    const currentRole = member?.role === "editors" ? "editor" : "reader";
+    const currentRole = normalizeMemberRole(member?.role);
     const memberUserId =
       member?.user_id ??
       member?.keycloak_user_id ??
@@ -1310,13 +1315,16 @@ const handleApplyNodeRed = async (groupId: string) => {
                         <TableCell sx={{ py: 1.2 }}>{`${member?.first_name} ${member?.last_name}`}</TableCell>
                         <TableCell sx={{ py: 1.2 }}>{member?.email}</TableCell>
                         <TableCell>
+                          {(() => {
+                            const role = normalizeMemberRole(member?.role);
+                            return (
                           <Chip
-                            label={(member?.role  === "Editors" ? "editor" : "reader").toUpperCase()}
+                            label={role.toUpperCase()}
                             size="small"
-                            color={member?.role === "Editors" ? "secondary" : "primary"}
+                            color={role === "editor" ? "secondary" : "primary"}
                             variant="filled"
                             sx={
-                              member?.role === "Editors"
+                              role === "editor"
                                 ? {}
                                 : {
                                     backgroundColor: Colors.main,
@@ -1324,6 +1332,8 @@ const handleApplyNodeRed = async (groupId: string) => {
                                   }
                             }
                           />
+                            );
+                          })()}
                         </TableCell>
                         <TableCell sx={{ textAlign: "center" }}>
                           <Tooltip title="Change Role">

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -3,6 +3,7 @@ import { ToastContainer, toast } from "react-toastify";
 import { useKeycloak } from "@react-keycloak/web";
 import { useEffect, useState } from "react";
 import Dashboard from "../components/DashboardComponent";
+import EntityFormModal from "../components/EntityFormModal";
 
 import {
   Accordion,
@@ -99,6 +100,13 @@ export default function ListClients() {
     selectedRole: "reader",
   });
   const [memberActionSubmitting, setMemberActionSubmitting] = useState(false);
+  const [editProjectDialog, setEditProjectDialog] = useState<{
+    open: boolean;
+    groupId?: number;
+  }>({
+    open: false,
+  });
+  const [editProjectSubmitting, setEditProjectSubmitting] = useState(false);
   const [nodeRedMenuAnchor, setNodeRedMenuAnchor] = useState<null | HTMLElement>(null);
   const [nodeRedTargetGroup, setNodeRedTargetGroup] = useState<any>(null);
 
@@ -204,6 +212,51 @@ export default function ListClients() {
           }
         }
       });
+    },
+  });
+
+  const editProjectFormik = useFormik({
+    initialValues: {
+      name: "",
+      description: "",
+    },
+    validationSchema: Yup.object({
+      name: Yup.string().trim().required("Project name is required"),
+      description: Yup.string().trim().required("Project description is required"),
+    }),
+    onSubmit: async (values) => {
+      if (!editProjectDialog.groupId) {
+        toast.error("Project ID is missing.");
+        return;
+      }
+
+      try {
+        setEditProjectSubmitting(true);
+        const token = keycloak?.token;
+        await axios.patch(
+          `${process.env.REACT_APP_BACKEND_URL}/projects/${editProjectDialog.groupId}`,
+          {
+            project_name: values.name.trim(),
+            project_description: values.description.trim(),
+          },
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+          }
+        );
+        toast.success("Project updated successfully!");
+        setEditProjectDialog({
+          open: false,
+          groupId: undefined,
+        });
+        getAllGroups();
+      } catch (error: any) {
+        toast.error(error?.response?.data?.message || "Failed to update project.");
+      } finally {
+        setEditProjectSubmitting(false);
+      }
     },
   });
 
@@ -614,59 +667,23 @@ const handleApplyNodeRed = async (groupId: string) => {
     });
   };
 
-  // Update Project Function
+  const openEditProjectDialog = (group: any) => {
+    setEditProjectDialog({
+      open: true,
+      groupId: group?.id,
+    });
+    editProjectFormik.setValues({
+      name: group?.name || "",
+      description: group?.description || "",
+    });
+    editProjectFormik.setTouched({});
+  };
 
-  const handleEditProjectSwal = (group: any) => {
-    Swal.fire({
-      title: "Edit Project",
-      html: `
-     <div class="swal-input-row-with-label">` +
-        `<label for="name">New Name</label>` +
-        `<div class="swal-input-field">` +
-        `<input id="name" class="swal2-input" placeholder="Enter the new device name" value="${group?.name || ""
-        }">` +
-        `</div>` +
-        `</div>` +
-        `<div class="swal-input-row">` +
-        `<label for="description">New Description</label>` +
-        `<input id="description" class="swal2-input" placeholder="Enter the new device description" value="${group?.description || ""
-        }">` +
-        `</div>
-    `,
-      showCancelButton: true,
-      confirmButtonText: "Save",
-      showLoaderOnConfirm: true,
-      preConfirm: () => {
-        const name = (document.getElementById("name") as HTMLInputElement).value.trim();
-        const description = (document.getElementById("description") as HTMLInputElement).value.trim();
-
-        if (!name) {
-          Swal.showValidationMessage("Please enter a project name");
-          return false;
-        }
-
-        return { name, description };
-      },
-    }).then(async (result) => {
-      if (result.isConfirmed) {
-        try {
-          const token = keycloak?.token;
-          await axios.patch(`${process.env.REACT_APP_BACKEND_URL}/projects/${group.id}`, {
-            project_name: result.value.name,
-            project_description: result.value.description
-          }, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json"
-            }
-          });
-
-          await Swal.fire("Success", "Project updated successfully!", "success");
-          getAllGroups();
-        } catch (error) {
-          await Swal.fire("Error", "Failed to update project", "error");
-        }
-      }
+  const closeEditProjectDialog = () => {
+    if (editProjectSubmitting) return;
+    setEditProjectDialog({
+      open: false,
+      groupId: undefined,
     });
   };
 
@@ -820,7 +837,7 @@ const handleApplyNodeRed = async (groupId: string) => {
                                 </IconButton>
 
                                 {/* Edit Group */}
-                                <IconButton color="error" disabled={!group?.is_owner} onClick={() => handleEditProjectSwal(group)}>
+                                <IconButton color="error" disabled={!group?.is_owner} onClick={() => openEditProjectDialog(group)}>
                                   <Tooltip title="Edit Project">
                                     <EditOutlinedIcon />
                                   </Tooltip>
@@ -1121,6 +1138,36 @@ const handleApplyNodeRed = async (groupId: string) => {
           </Box>
         </>
       )}
+      <EntityFormModal
+        open={editProjectDialog.open}
+        onClose={closeEditProjectDialog}
+        title="Edit Project"
+        sectionTitle="Project Details"
+        formik={editProjectFormik}
+        fields={[
+          { name: "name", label: "Project Name", xs: 12, sm: 12 },
+          {
+            name: "description",
+            label: "Project Description",
+            multiline: true,
+            minRows: 3,
+            xs: 12,
+            sm: 12,
+          },
+        ]}
+        submitting={editProjectSubmitting}
+        submitLabel="Save"
+        primaryButtonSx={{
+          backgroundColor: Colors.main,
+          "&:hover": { backgroundColor: Colors.main, opacity: 0.95 },
+        }}
+        cancelButtonSx={{
+          borderColor: Colors.main,
+          color: Colors.main,
+          "&:hover": { borderColor: Colors.main, backgroundColor: "rgba(35,48,68,0.06)" },
+        }}
+      />
+
       <Dialog
         open={Boolean(memberModalGroup)}
         onClose={(_, reason) => {

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -86,6 +86,8 @@ export default function ListClients() {
     open: boolean;
     type: "approve" | "reject" | "changeRole";
     membershipId?: any;
+    userId?: any;
+    serviceId?: any;
     memberName?: string;
     currentRole?: "reader" | "editor";
     selectedRole: "reader" | "editor";
@@ -94,6 +96,7 @@ export default function ListClients() {
     type: "approve",
     selectedRole: "reader",
   });
+  const [memberActionSubmitting, setMemberActionSubmitting] = useState(false);
   const [nodeRedMenuAnchor, setNodeRedMenuAnchor] = useState<null | HTMLElement>(null);
   const [nodeRedTargetGroup, setNodeRedTargetGroup] = useState<any>(null);
 
@@ -344,10 +347,21 @@ export default function ListClients() {
   ) => {
     const memberName = `${member?.first_name || ""} ${member?.last_name || ""}`.trim();
     const currentRole = member?.role === "editor" ? "editor" : "reader";
+    const memberUserId =
+      member?.user_id ??
+      member?.keycloak_user_id ??
+      member?.userid ??
+      member?.id;
+    const serviceId =
+      memberModalGroup?.id ??
+      memberModalGroup?.service_id ??
+      memberModalGroup?.keycloak_group_id;
     setMemberActionDialog({
       open: true,
       type,
       membershipId: member?.membership_id,
+      userId: memberUserId,
+      serviceId,
       memberName,
       currentRole,
       selectedRole: type === "changeRole" ? currentRole : "reader",
@@ -355,6 +369,7 @@ export default function ListClients() {
   };
 
   const closeMemberActionDialog = () => {
+    if (memberActionSubmitting) return;
     setMemberActionDialog((prev) => ({ ...prev, open: false }));
   };
 
@@ -369,6 +384,7 @@ export default function ListClients() {
       return;
     }
 
+    setMemberActionSubmitting(true);
     try {
       if (memberActionDialog.type === "approve" || memberActionDialog.type === "reject") {
         const action = memberActionDialog.type;
@@ -391,24 +407,21 @@ export default function ListClients() {
           closeMemberActionDialog();
           return;
         }
+        if (!memberActionDialog.serviceId || !memberActionDialog.userId) {
+          toast.error("Missing service_id or user_id for role update.");
+          return;
+        }
 
         const payload = {
-          membership_id: memberActionDialog.membershipId,
+          service_id: memberActionDialog.serviceId,
+          user_id: memberActionDialog.userId,
           role: memberActionDialog.selectedRole,
         };
-        try {
-          await axios.post(
-            `${process.env.REACT_APP_BACKEND_URL}/change_member_role`,
-            payload,
-            { headers: { Authorization: `Bearer ${token}` } }
-          );
-        } catch {
-          await axios.post(
-            `${process.env.REACT_APP_BACKEND_URL}/manage_membership`,
-            { membership_id: memberActionDialog.membershipId, action: "change_role", role: memberActionDialog.selectedRole },
-            { headers: { Authorization: `Bearer ${token}` } }
-          );
-        }
+        await axios.post(
+          `${process.env.REACT_APP_BACKEND_URL}/change_member_role`,
+          payload,
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
         toast.success("Member role updated successfully.");
       }
 
@@ -416,6 +429,8 @@ export default function ListClients() {
       getAllGroups();
     } catch (error: any) {
       toast.error(error?.response?.data?.message || "Failed to update member.");
+    } finally {
+      setMemberActionSubmitting(false);
     }
   };
   const openMemberModal = (group: any, tab: "members" | "pending") => {
@@ -432,6 +447,14 @@ export default function ListClients() {
     memberModalGroup?.members?.filter((x: any) => x?.membership_status === "approved") || [];
   const pendingMembers =
     memberModalGroup?.members?.filter((x: any) => x?.membership_status === "pending") || [];
+
+  useEffect(() => {
+    if (!memberModalGroup?.id) return;
+    const refreshedGroup = myGroups.find((g: any) => g?.id === memberModalGroup.id);
+    if (refreshedGroup) {
+      setMemberModalGroup(refreshedGroup);
+    }
+  }, [myGroups, memberModalGroup?.id]);
 
   const handleNodeRedMenuOpen = (
     event: React.MouseEvent<HTMLElement>,
@@ -1159,6 +1182,7 @@ const handleApplyNodeRed = async (groupId: string) => {
                     labelId="member-role-label"
                     label="Role"
                     value={memberActionDialog.selectedRole}
+                    disabled={memberActionSubmitting}
                     onChange={(e) =>
                       setMemberActionDialog((prev) => ({
                         ...prev,
@@ -1176,6 +1200,7 @@ const handleApplyNodeRed = async (groupId: string) => {
                 <Button
                   variant="outlined"
                   onClick={closeMemberActionDialog}
+                  disabled={memberActionSubmitting}
                   size="small"
                   sx={{
                     borderColor: Colors.main,
@@ -1193,6 +1218,7 @@ const handleApplyNodeRed = async (groupId: string) => {
                 <Button
                   variant="contained"
                   onClick={submitMemberActionDialog}
+                  disabled={memberActionSubmitting}
                   size="small"
                   sx={{
                     backgroundColor: Colors.main,
@@ -1203,7 +1229,7 @@ const handleApplyNodeRed = async (groupId: string) => {
                     "&:hover": { backgroundColor: Colors.main, opacity: 0.95 },
                   }}
                 >
-                  Confirm
+                  {memberActionSubmitting ? "Confirming..." : "Confirm"}
                 </Button>
               </Box>
             </Box>

--- a/src/pages/ListClients.tsx
+++ b/src/pages/ListClients.tsx
@@ -352,7 +352,7 @@ export default function ListClients() {
     member: any
   ) => {
     const memberName = `${member?.first_name || ""} ${member?.last_name || ""}`.trim();
-    const currentRole = member?.role === "editor" ? "editor" : "reader";
+    const currentRole = member?.role === "editors" ? "editor" : "reader";
     const memberUserId =
       member?.user_id ??
       member?.keycloak_user_id ??
@@ -1298,12 +1298,12 @@ const handleApplyNodeRed = async (groupId: string) => {
                         <TableCell sx={{ py: 1.2 }}>{member?.email}</TableCell>
                         <TableCell>
                           <Chip
-                            label={(member?.role || "reader").toUpperCase()}
+                            label={(member?.role  === "Editors" ? "editor" : "reader").toUpperCase()}
                             size="small"
-                            color={member?.role === "editor" ? "secondary" : "primary"}
+                            color={member?.role === "Editors" ? "secondary" : "primary"}
                             variant="filled"
                             sx={
-                              member?.role === "editor"
+                              member?.role === "Editors"
                                 ? {}
                                 : {
                                     backgroundColor: Colors.main,

--- a/src/pages/datastreams/ListDatastream.tsx
+++ b/src/pages/datastreams/ListDatastream.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import axios from "axios";
 import { useFormik } from "formik";
 import { Breadcrumbs, Button, Typography } from "@mui/material";
@@ -17,6 +17,7 @@ import { useAppSelector, useIsOwner } from "../../hooks/hooks";
 import DataTableCardV2 from "../../components/DataGridServerSide"
 import BiotechSharpIcon from "@mui/icons-material/BiotechSharp";
 import EntityFormModal from "../../components/EntityFormModal";
+import ConfirmDeleteDialog from "../../components/ConfirmDeleteDialog";
 import { editDatastreamValidationSchema } from "../../formik/validation_schema";
 
 const DESCRIPTION_WORD_LIMIT = 7;
@@ -83,6 +84,9 @@ const ListDatastream = () => {
   const [editOpen, setEditOpen] = useState(false);
   const [editingDatastreamId, setEditingDatastreamId] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [datastreamToDelete, setDatastreamToDelete] = useState<any | null>(null);
   const selectedGroupId = useAppSelector(
     (state) => state.roles.selectedGroupId
   );
@@ -246,42 +250,93 @@ const fetchDatastreams = useCallback(
     }
   };
 
-  const handleDeleteDatastream = async (id: number) => {
-    const backend_url = process.env.REACT_APP_BACKEND_URL_ROOT;
-    const isDev = process.env.REACT_APP_IS_DEVELOPMENT === "true";
-    const baseUrl = isDev
-      ? `${backend_url}:${frostServerPort}`
-      : `https://${frostServerPort}-${process.env.REACT_APP_FROST_URL}`;
-
-    try {
-      const confirmed = await Swal.fire({
-        title: "Are you sure?",
-        text: "This will permanently delete the datastream.",
-        icon: "warning",
-        showCancelButton: true,
-        confirmButtonColor: "#d33",
-        cancelButtonColor: "#3085d6",
-        confirmButtonText: "Yes, delete it!",
+  const openEditDialog = useCallback(
+    (row: any) => {
+      setEditingDatastreamId(row?.["@iot.id"]);
+      editFormik.setValues({
+        description: row?.description || "",
+        unit_name: row?.unitOfMeasurement?.name || "",
+        unit_symbol: row?.unitOfMeasurement?.symbol || "",
+        unit_definition: row?.unitOfMeasurement?.definition || "",
       });
+      setEditOpen(true);
+    },
+    [editFormik.setValues]
+  );
 
-      if (confirmed.isConfirmed) {
-        const deleteUrl = `${baseUrl}/FROST-Server/v1.0/Datastreams(${id})`;
+  const openDeleteDialog = useCallback((row: any) => {
+    setDatastreamToDelete(row);
+    setDeleteOpen(true);
+  }, []);
 
-        await axios.delete(deleteUrl, {
+  const closeDeleteDialog = useCallback(() => {
+    if (deleting) return;
+    setDeleteOpen(false);
+    setDatastreamToDelete(null);
+  }, [deleting]);
+
+  const confirmDeleteDatastream = useCallback(async () => {
+    if (!datastreamToDelete) return;
+    try {
+      setDeleting(true);
+      const response = await axios.post(
+        `${process.env.REACT_APP_BACKEND_URL}/delete`,
+        {
+          url: `Datastreams(${datastreamToDelete["@iot.id"]})`,
+          FROST_PORT: frostServerPort,
+          keycloak_id: userInfo?.sub,
+        },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `${token}`,
+          },
+        }
+      );
+
+      if (response.status === 200) {
+        Swal.fire({
+          icon: "success",
+          title: "Deleted!",
+          text: `Datastream "${datastreamToDelete.name}" deleted successfully!`,
+        });
+        setDatastreams((prev) => prev.filter((ds) => ds["@iot.id"] !== datastreamToDelete["@iot.id"]));
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "Oops...",
+          text: "Datastream not deleted! Try again.",
+        });
+      }
+    } catch {
+      axios.post(
+        `http://localhost:4500/mutation_error_logs`,
+        {
+          keycloak_id: userInfo?.sub,
+          method: "DELETE",
+          attribute: "Datastreams",
+          attribute_id: datastreamToDelete["@iot.id"],
+          frost_port: frostServerPort,
+        },
+        {
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
           },
-        });
+        }
+      );
 
-        toast.success("Datastream deleted successfully!");
-        fetchDatastreams(); // Refresh the list
-      }
-    } catch (error) {
-      console.error("Error deleting datastream:", error);
-      toast.error("Failed to delete datastream");
+      Swal.fire({
+        icon: "error",
+        title: "Error",
+        text: "Something went wrong while deleting the datastream.",
+      });
+    } finally {
+      setDeleting(false);
+      setDeleteOpen(false);
+      setDatastreamToDelete(null);
     }
-  };
+  }, [datastreamToDelete, frostServerPort, token, userInfo?.sub]);
 
  const handlePageChange = (newPage: number) => {
   setPage(newPage);
@@ -309,7 +364,7 @@ const handlePageSizeChange = (newPageSize: number) => {
     }
   }, [frostServerPort]);
 
-  const columns = [
+  const columns = useMemo(() => [
     {
       headerName: "ID",
       field: "@iot.id",
@@ -387,14 +442,7 @@ const handlePageSizeChange = (newPageSize: number) => {
           onClick={() => {
             const row = params?.data;
             if (!isOwner) return;
-            setEditingDatastreamId(row?.["@iot.id"]);
-            editFormik.setValues({
-              description: row?.description || "",
-              unit_name: row?.unitOfMeasurement?.name || "",
-              unit_symbol: row?.unitOfMeasurement?.symbol || "",
-              unit_definition: row?.unitOfMeasurement?.definition || "",
-            });
-            setEditOpen(true);
+            openEditDialog(row);
           }}
         />
       ),
@@ -415,78 +463,7 @@ const handlePageSizeChange = (newPageSize: number) => {
           onClick={() => {
             if (!isOwner) return;
             const row = params?.data;
-            Swal.fire({
-              title: `Delete "${row.name}"?`,
-              text: "This will permanently delete the datastream and its related data!",
-              icon: "warning",
-              showCancelButton: true,
-              confirmButtonColor: "#3085d6",
-              cancelButtonColor: "#d33",
-              confirmButtonText: "Yes, delete it!",
-            }).then(async (result) => {
-              if (result.isConfirmed) {
-                try {
-                  const response = await axios.post(
-                    `${process.env.REACT_APP_BACKEND_URL}/delete`,
-                    {
-                      url: `Datastreams(${row["@iot.id"]})`,
-                      FROST_PORT: frostServerPort,
-                      keycloak_id: userInfo?.sub,
-                    },
-                    {
-                      headers: {
-                        "Content-Type": "application/json",
-                        Authorization: `${token}`, // 👈 No "Bearer" prefix since your current API works that way
-                      },
-                    }
-                  );
-
-                  if (response.status === 200) {
-                    Swal.fire({
-                      icon: "success",
-                      title: "Deleted!",
-                      text: `Datastream "${row.name}" deleted successfully!`,
-                    });
-
-                    // Remove the deleted datastream from state
-                    const updatedList = datastreams.filter(
-                      (ds) => ds["@iot.id"] !== row["@iot.id"]
-                    );
-                    setDatastreams(updatedList);
-                  } else {
-                    Swal.fire({
-                      icon: "error",
-                      title: "Oops...",
-                      text: "Datastream not deleted! Try again.",
-                    });
-                  }
-                } catch (error) {
-                  // Log error via your error tracking API
-                  axios.post(
-                    `http://localhost:4500/mutation_error_logs`,
-                    {
-                      keycloak_id: userInfo?.sub,
-                      method: "DELETE",
-                      attribute: "Datastreams",
-                      attribute_id: row["@iot.id"],
-                      frost_port: frostServerPort,
-                    },
-                    {
-                      headers: {
-                        "Content-Type": "application/json",
-                        Authorization: `Bearer ${token}`,
-                      },
-                    }
-                  );
-
-                  Swal.fire({
-                    icon: "error",
-                    title: "Error",
-                    text: "Something went wrong while deleting the datastream.",
-                  });
-                }
-              }
-            });
+            openDeleteDialog(row);
           }}
         />
       ),
@@ -530,7 +507,7 @@ const handlePageSizeChange = (newPageSize: number) => {
       sortable: false,
       filter: false,
     },
-  ];
+  ], [isOwner, openDeleteDialog, openEditDialog]);
 
 
   return (
@@ -622,6 +599,16 @@ const handlePageSizeChange = (newPageSize: number) => {
         submitting={saving}
         submitLabel="Save"
         primaryButtonSx={primaryButtonSx}
+        cancelButtonSx={cancelButtonSx}
+      />
+      <ConfirmDeleteDialog
+        open={deleteOpen}
+        title="Delete Datastream"
+        entityName={datastreamToDelete?.name || ""}
+        description="This will permanently delete the datastream and its related data."
+        loading={deleting}
+        onCancel={closeDeleteDialog}
+        onConfirm={confirmDeleteDatastream}
         cancelButtonSx={cancelButtonSx}
       />
     </Dashboard>

--- a/src/pages/devices/ListDevices.tsx
+++ b/src/pages/devices/ListDevices.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import { useFormik } from "formik";
 import {
@@ -21,6 +21,7 @@ import MapIcon from "@mui/icons-material/Map";
 import { useAppSelector, useIsOwner } from "../../hooks/hooks";
 import DataTableCardV2 from "../../components/DataGridServerSide";
 import EntityFormModal from "../../components/EntityFormModal";
+import ConfirmDeleteDialog from "../../components/ConfirmDeleteDialog";
 import { editDeviceValidationSchema } from "../../formik/validation_schema";
 
 const Devices = () => {
@@ -40,6 +41,9 @@ const Devices = () => {
   const [editOpen, setEditOpen] = useState(false);
   const [editingDeviceId, setEditingDeviceId] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deviceToDelete, setDeviceToDelete] = useState<any | null>(null);
   const isOwner = useIsOwner();
   const primaryButtonSx = {
     backgroundColor: "rgb(35, 48, 68)",
@@ -174,7 +178,81 @@ const Devices = () => {
     }
   }, [frostServerPort]);
 
-  const columnDefs = [
+  const openEditDialog = useCallback(
+    (row: any) => {
+      setEditingDeviceId(row?.["@iot.id"]);
+      editFormik.setValues({
+        name: row?.name || "",
+        description: row?.description || "",
+      });
+      setEditOpen(true);
+    },
+    [editFormik.setValues]
+  );
+
+  const openDeleteDialog = useCallback((row: any) => {
+    setDeviceToDelete(row);
+    setDeleteOpen(true);
+  }, []);
+
+  const closeDeleteDialog = useCallback(() => {
+    if (deleting) return;
+    setDeleteOpen(false);
+    setDeviceToDelete(null);
+  }, [deleting]);
+
+  const confirmDeleteDevice = useCallback(async () => {
+    if (!deviceToDelete) return;
+
+    try {
+      setDeleting(true);
+      const response = await axios.post(
+        `${process.env.REACT_APP_BACKEND_URL}/delete`,
+        {
+          url: `Things(${deviceToDelete["@iot.id"]})`,
+          FROST_PORT: frostServerPort,
+          keycloak_id: userInfo?.sub,
+        },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `${token}`,
+          },
+        }
+      );
+
+      if (response.status === 200) {
+        Swal.fire({ icon: "success", title: "Success", text: "Device deleted successfully!" });
+        setDevices((prev) => prev.filter((device) => device["@iot.id"] !== deviceToDelete["@iot.id"]));
+      } else {
+        Swal.fire({ icon: "error", title: "Oops...", text: "Something went wrong! Device not deleted!" });
+      }
+    } catch {
+      axios.post(
+        `http://localhost:4500/mutation_error_logs`,
+        {
+          keycloak_id: userInfo?.sub,
+          method: "DELETE",
+          attribute: "Devices",
+          attribute_id: deviceToDelete["@iot.id"],
+          frost_port: frostServerPort,
+        },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      Swal.fire({ icon: "error", title: "Oops...", text: "Something went wrong! Device not deleted!" });
+    } finally {
+      setDeleting(false);
+      setDeleteOpen(false);
+      setDeviceToDelete(null);
+    }
+  }, [deviceToDelete, frostServerPort, token, userInfo?.sub]);
+
+  const columnDefs = useMemo(() => [
     {
       headerName: "ID",
       field: "@iot.id",
@@ -231,12 +309,7 @@ const Devices = () => {
             }}
             onClick={() => {
               if (!isOwner) return;
-              setEditingDeviceId(row?.["@iot.id"]);
-              editFormik.setValues({
-                name: row?.name || "",
-                description: row?.description || "",
-              });
-              setEditOpen(true);
+              openEditDialog(row);
             }}
           />
         );
@@ -259,77 +332,7 @@ const Devices = () => {
             }}
             onClick={() => {
               if (!isOwner) return;
-
-              Swal.fire({
-                title: `Are you sure you want to delete ${row.name}?`,
-                text: "You will not be able to recover this device! Linked datastream might become dysfunctional!",
-                icon: "warning",
-                showCancelButton: true,
-                confirmButtonColor: "#3085d6",
-                cancelButtonColor: "#d33",
-                confirmButtonText: "Yes, delete it!",
-              }).then(async (result) => {
-                if (result.isConfirmed) {
-                  try {
-                    const response = await axios.post(
-                      `${process.env.REACT_APP_BACKEND_URL}/delete`,
-                      {
-                        url: `Things(${row["@iot.id"]})`,
-                        FROST_PORT: frostServerPort,
-                        keycloak_id: userInfo?.sub,
-                      },
-                      {
-                        headers: {
-                          "Content-Type": "application/json",
-                          Authorization: `${token}`,
-                        },
-                      }
-                    );
-
-                    if (response.status === 200) {
-                      Swal.fire({
-                        icon: "success",
-                        title: "Success",
-                        text: "Device deleted successfully!",
-                      });
-
-                      const newDevices = devices.filter(
-                        (device) => device["@iot.id"] !== row["@iot.id"]
-                      );
-                      setDevices(newDevices);
-                    } else {
-                      Swal.fire({
-                        icon: "error",
-                        title: "Oops...",
-                        text: "Something went wrong! Device not deleted!",
-                      });
-                    }
-                  } catch (error) {
-                    axios.post(
-                      `http://localhost:4500/mutation_error_logs`,
-                      {
-                        keycloak_id: userInfo?.sub,
-                        method: "DELETE",
-                        attribute: "Devices",
-                        attribute_id: row["@iot.id"],
-                        frost_port: frostServerPort,
-                      },
-                      {
-                        headers: {
-                          "Content-Type": "application/json",
-                          Authorization: `Bearer ${token}`,
-                        },
-                      }
-                    );
-
-                    Swal.fire({
-                      icon: "error",
-                      title: "Oops...",
-                      text: "Something went wrong! Device not deleted!",
-                    });
-                  }
-                }
-              });
+              openDeleteDialog(row);
             }}
           />
         );
@@ -358,7 +361,7 @@ const Devices = () => {
         );
       },
     },
-  ];
+  ], [isOwner, openDeleteDialog, openEditDialog]);
 
   const handlePageChange = (newPage: number) => {
     setPage(newPage);
@@ -460,6 +463,16 @@ Each device can have one or more datastreams (e.g., temperature, humidity) that 
         submitting={saving}
         submitLabel="Save"
         primaryButtonSx={primaryButtonSx}
+        cancelButtonSx={cancelButtonSx}
+      />
+      <ConfirmDeleteDialog
+        open={deleteOpen}
+        title="Delete Device"
+        entityName={deviceToDelete?.name || ""}
+        description="You will not be able to recover this device. Linked datastreams might become dysfunctional."
+        loading={deleting}
+        onCancel={closeDeleteDialog}
+        onConfirm={confirmDeleteDevice}
         cancelButtonSx={cancelButtonSx}
       />
     </Dashboard>

--- a/src/pages/location/ListLocation.tsx
+++ b/src/pages/location/ListLocation.tsx
@@ -155,6 +155,7 @@ const ListLocations = () => {
           $top: newPageSize,
           $skip: newPage * newPageSize,
           $count: true,
+          $expand: "Things($select=@iot.id)",
           ...(filter && { $filter: filter }),
           ...(sort && { $orderby: sort }),
         },
@@ -261,16 +262,18 @@ const ListLocations = () => {
       headerName: "Edit",
       cellRenderer: (params: any) => {
         const row = params.data;
+        const hasLinkedThing = Boolean(row?.Things?.[0]?.["@iot.id"]);
+        const canEdit = isOwner && hasLinkedThing;
         return (
           <EditOutlinedIcon
             style={{
-              cursor: isOwner ? "pointer" : "not-allowed",
-              color: isOwner ? "red" : "gray",
-              opacity: isOwner ? 1 : 0.4,
-              pointerEvents: isOwner ? "auto" : "none",
+              cursor: canEdit ? "pointer" : "not-allowed",
+              color: canEdit ? "red" : "gray",
+              opacity: canEdit ? 1 : 0.4,
+              pointerEvents: canEdit ? "auto" : "none",
             }}
             onClick={() => {
-              if (!isOwner) return;
+              if (!canEdit) return;
               const currentLat = row?.location?.coordinates?.[1];
               const currentLng = row?.location?.coordinates?.[0];
               setEditingLocationId(row?.["@iot.id"]);

--- a/src/pages/location/ListLocation.tsx
+++ b/src/pages/location/ListLocation.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import axios from "axios";
 import { useFormik } from "formik";
 import { Breadcrumbs, Button, Typography } from "@mui/material";
@@ -16,6 +16,7 @@ import { useIsOwner } from "../../hooks/hooks";
 import DeleteForeverOutlinedIcon from "@mui/icons-material/DeleteForeverOutlined";
 import DataTableCardV2 from "../../components/DataGridServerSide";
 import EntityFormModal from "../../components/EntityFormModal";
+import ConfirmDeleteDialog from "../../components/ConfirmDeleteDialog";
 import { editLocationValidationSchema } from "../../formik/validation_schema";
 
 const ListLocations = () => {
@@ -36,6 +37,9 @@ const ListLocations = () => {
   const [editOpen, setEditOpen] = useState(false);
   const [editingLocationId, setEditingLocationId] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [locationToDelete, setLocationToDelete] = useState<any | null>(null);
 
   const isOwner = useIsOwner();
   const primaryButtonSx = {
@@ -215,7 +219,40 @@ const ListLocations = () => {
     }
   }, [frostServerPort]);
 
-  const columnDefs = [
+  const openDeleteDialog = useCallback((row: any) => {
+    setLocationToDelete(row);
+    setDeleteOpen(true);
+  }, []);
+
+  const closeDeleteDialog = useCallback(() => {
+    if (deleting) return;
+    setDeleteOpen(false);
+    setLocationToDelete(null);
+  }, [deleting]);
+
+  const openEditDialog = useCallback(
+    (row: any) => {
+      const currentLat = row?.location?.coordinates?.[1];
+      const currentLng = row?.location?.coordinates?.[0];
+      setEditingLocationId(row?.["@iot.id"]);
+      editFormik.setValues({
+        name: row?.name || "",
+        description: row?.description || "",
+        latitude:
+          currentLat !== undefined && currentLat !== null
+            ? String(currentLat)
+            : "",
+        longitude:
+          currentLng !== undefined && currentLng !== null
+            ? String(currentLng)
+            : "",
+      });
+      setEditOpen(true);
+    },
+    [editFormik.setValues]
+  );
+
+  const columnDefs = useMemo(() => [
     {
       headerName: "ID",
       field: "@iot.id",
@@ -274,22 +311,7 @@ const ListLocations = () => {
             }}
             onClick={() => {
               if (!canEdit) return;
-              const currentLat = row?.location?.coordinates?.[1];
-              const currentLng = row?.location?.coordinates?.[0];
-              setEditingLocationId(row?.["@iot.id"]);
-              editFormik.setValues({
-                name: row?.name || "",
-                description: row?.description || "",
-                latitude:
-                  currentLat !== undefined && currentLat !== null
-                    ? String(currentLat)
-                    : "",
-                longitude:
-                  currentLng !== undefined && currentLng !== null
-                    ? String(currentLng)
-                    : "",
-              });
-              setEditOpen(true);
+              openEditDialog(row);
             }}
           />
         );
@@ -311,48 +333,7 @@ const ListLocations = () => {
             }}
             onClick={() => {
               if (!isOwner) return;
-              Swal.fire({
-                title: `Are you sure you want to delete "${row.name}"?`,
-                text: "This will permanently delete the location!",
-                icon: "warning",
-                showCancelButton: true,
-                confirmButtonText: "Yes, delete it!",
-              }).then(async (result) => {
-                if (result.isConfirmed) {
-                  try {
-                    const response = await axios.post(
-                      `${process.env.REACT_APP_BACKEND_URL}/delete`,
-                      {
-                        url: `Locations(${row["@iot.id"]})`,
-                        FROST_PORT: frostServerPort,
-                        keycloak_id: userInfo?.sub,
-                      },
-                      {
-                        headers: {
-                          "Content-Type": "application/json",
-                          Authorization: `Bearer ${token}`,
-                        },
-                      }
-                    );
-
-                    if (response.status === 200) {
-                      Swal.fire("Deleted!", "Location deleted successfully!", "success");
-                      setLocations(locations.filter((loc: any) => loc["@iot.id"] !== row["@iot.id"]));
-                    } else {
-                      Swal.fire("Error", "Location not deleted!", "error");
-                    }
-                  } catch {
-                    axios.post("http://localhost:4500/mutation_error_logs", {
-                      keycloak_id: userInfo?.sub,
-                      method: "DELETE",
-                      attribute: "Locations",
-                      attribute_id: row["@iot.id"],
-                      frost_port: frostServerPort,
-                    });
-                    Swal.fire("Error", "Something went wrong while deleting.", "error");
-                  }
-                }
-              });
+              openDeleteDialog(row);
             }}
           />
         );
@@ -370,7 +351,7 @@ const ListLocations = () => {
       ),
       filter: false
     },
-  ];
+  ], [isOwner, openDeleteDialog, openEditDialog]);
 
   const handlePageChange = (newPage: number) => {
     setPage(newPage);
@@ -382,6 +363,50 @@ const ListLocations = () => {
     setPageSize(newPageSize);
     setPageLinks({});
     fetchLocations(0, newPageSize, filterQuery, sortQuery);
+  };
+
+  const confirmDeleteLocation = async () => {
+    if (!locationToDelete) return;
+
+    try {
+      setDeleting(true);
+      const response = await axios.post(
+        `${process.env.REACT_APP_BACKEND_URL}/delete`,
+        {
+          url: `Locations(${locationToDelete["@iot.id"]})`,
+          FROST_PORT: frostServerPort,
+          keycloak_id: userInfo?.sub,
+        },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (response.status === 200) {
+        Swal.fire("Deleted!", "Location deleted successfully!", "success");
+        setLocations(
+          locations.filter((loc: any) => loc["@iot.id"] !== locationToDelete["@iot.id"])
+        );
+      } else {
+        Swal.fire("Error", "Location not deleted!", "error");
+      }
+    } catch {
+      axios.post("http://localhost:4500/mutation_error_logs", {
+        keycloak_id: userInfo?.sub,
+        method: "DELETE",
+        attribute: "Locations",
+        attribute_id: locationToDelete["@iot.id"],
+        frost_port: frostServerPort,
+      });
+      Swal.fire("Error", "Something went wrong while deleting.", "error");
+    } finally {
+      setDeleting(false);
+      setDeleteOpen(false);
+      setLocationToDelete(null);
+    }
   };
 
 
@@ -475,6 +500,19 @@ Each location includes a name, description, and geographic coordinates, and can 
         submitting={saving}
         submitLabel="Save"
         primaryButtonSx={primaryButtonSx}
+        cancelButtonSx={cancelButtonSx}
+      />
+      <ConfirmDeleteDialog
+        open={deleteOpen}
+        title="Delete Location"
+        entityName={locationToDelete?.name || ""}
+        description="This will remove the location and its map reference from this list."
+        warningText="This action is permanent and cannot be undone."
+        loading={deleting}
+        onCancel={closeDeleteDialog}
+        onConfirm={confirmDeleteLocation}
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
         cancelButtonSx={cancelButtonSx}
       />
 

--- a/src/pages/observation_property/ListObservationProperty.tsx
+++ b/src/pages/observation_property/ListObservationProperty.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import axios from "axios";
 import { useFormik } from "formik";
 import { Breadcrumbs, Button, Typography } from "@mui/material";
@@ -16,6 +16,7 @@ import { GAactionsObservationProperties } from "../../utils/GA";
 import { useAppSelector, useIsOwner } from "../../hooks/hooks";
 import DataTableCardV2 from "../../components/DataGridServerSide";
 import EntityFormModal from "../../components/EntityFormModal";
+import ConfirmDeleteDialog from "../../components/ConfirmDeleteDialog";
 import { editObservationPropertyValidationSchema } from "../../formik/validation_schema";
 
 const ListObservationProperty = () => {
@@ -37,6 +38,9 @@ const [sortQuery, setSortQuery] = useState("");
   const [editOpen, setEditOpen] = useState(false);
   const [editingObservedPropertyId, setEditingObservedPropertyId] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [observationPropertyToDelete, setObservationPropertyToDelete] = useState<any | null>(null);
   const selectedGroupId = useAppSelector(state => state.roles.selectedGroupId);
   const group = useAppSelector(state =>
     state.roles.groups.find(g => g?.group_name_id === selectedGroupId)
@@ -208,7 +212,91 @@ const [sortQuery, setSortQuery] = useState("");
 }, [frostServerPort]);
 
 
-  const columns = [
+  const openEditDialog = useCallback(
+    (row: any) => {
+      setEditingObservedPropertyId(row?.["@iot.id"]);
+      editFormik.setValues({
+        name: row?.name || "",
+        description: row?.description || "",
+        definition: row?.definition || "",
+      });
+      setEditOpen(true);
+    },
+    [editFormik.setValues]
+  );
+
+  const openDeleteDialog = useCallback((row: any) => {
+    setObservationPropertyToDelete(row);
+    setDeleteOpen(true);
+  }, []);
+
+  const closeDeleteDialog = useCallback(() => {
+    if (deleting) return;
+    setDeleteOpen(false);
+    setObservationPropertyToDelete(null);
+  }, [deleting]);
+
+  const confirmDeleteObservationProperty = useCallback(async () => {
+    if (!observationPropertyToDelete) return;
+    try {
+      setDeleting(true);
+      const response = await axios.post(
+        `${process.env.REACT_APP_BACKEND_URL}/delete`,
+        {
+          url: `ObservedProperties(${observationPropertyToDelete["@iot.id"]})`,
+          FROST_PORT: frostServerPort,
+          keycloak_id: userInfo?.sub,
+        },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `${token}`,
+          },
+        }
+      );
+
+      if (response.status === 200) {
+        Swal.fire({ icon: "success", title: "Success", text: "Measurement Property deleted successfully!" });
+        setObservationProperty((prev) =>
+          prev.filter((observation_property) => observation_property["@iot.id"] !== observationPropertyToDelete["@iot.id"])
+        );
+      } else {
+        Swal.fire({
+          icon: "error",
+          title: "Oops...",
+          text: "Something went wrong! Measurement Property not deleted!",
+        });
+      }
+    } catch {
+      await axios.post(
+        `http://localhost:4500/mutation_error_logs`,
+        {
+          keycloak_id: userInfo?.sub,
+          method: "DELETE",
+          attribute: "Measurement Property",
+          attribute_id: observationPropertyToDelete["@iot.id"],
+          frost_port: frostServerPort,
+        },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${keycloak?.token}`,
+          },
+        }
+      );
+      Swal.fire({
+        icon: "error",
+        title: "Oops...",
+        text: "Something went wrong! Measurement Property not deleted!",
+      });
+    } finally {
+      setDeleting(false);
+      setDeleteOpen(false);
+      setObservationPropertyToDelete(null);
+    }
+  }, [frostServerPort, keycloak?.token, observationPropertyToDelete, token, userInfo?.sub]);
+
+  const columns = useMemo(() => [
     {
       headerName: "ID",
       field: "@iot.id",
@@ -259,13 +347,7 @@ const [sortQuery, setSortQuery] = useState("");
           onClick={() => {
             const row = params?.data;
             if (!isOwner) return;
-            setEditingObservedPropertyId(row?.["@iot.id"]);
-            editFormik.setValues({
-              name: row?.name || "",
-              description: row?.description || "",
-              definition: row?.definition || "",
-            });
-            setEditOpen(true);
+            openEditDialog(row);
           }}
         />
       ),
@@ -285,82 +367,14 @@ const [sortQuery, setSortQuery] = useState("");
           onClick={() => {
             const row = params?.data;
             if (!isOwner) return;
-            Swal.fire({
-              title: `Are you sure you want to delete ${row.name}?`,
-              text: "You will not be able to recover this Measurement Property! Linked datastream might become disfunctional!",
-              icon: "warning",
-              showCancelButton: true,
-              confirmButtonColor: "#3085d6",
-              cancelButtonColor: "#d33",
-              confirmButtonText: "Yes, delete it!",
-            }).then(async (result) => {
-              if (result.isConfirmed) {
-                try {
-                  const response = await axios.post(
-                    `${process.env.REACT_APP_BACKEND_URL}/delete`,
-                    {
-                      url: `ObservedProperties(${row["@iot.id"]})`,
-                      FROST_PORT: frostServerPort,
-                      keycloak_id: userInfo?.sub,
-                    },
-                    {
-                      headers: {
-                        "Content-Type": "application/json",
-                        Authorization: `${token}`,
-                      },
-                    }
-                  );
-
-                  if (response.status === 200) {
-                    Swal.fire({
-                      icon: "success",
-                      title: "Success",
-                      text: "Measurement Property deleted successfully!",
-                    });
-                    const newObservationProperty = observationProperty.filter(
-                      (observation_property) =>
-                        observation_property["@iot.id"] !== row["@iot.id"]
-                    );
-                    setObservationProperty(newObservationProperty);
-                  } else {
-                    Swal.fire({
-                      icon: "error",
-                      title: "Oops...",
-                      text: "Something went wrong! Measurement Property not deleted!",
-                    });
-                  }
-                } catch (error) {
-                  await axios.post(
-                    `http://localhost:4500/mutation_error_logs`,
-                    {
-                      keycloak_id: userInfo?.sub,
-                      method: "DELETE",
-                      attribute: "Measurement Property",
-                      attribute_id: row["@iot.id"],
-                      frost_port: frostServerPort,
-                    },
-                    {
-                      headers: {
-                        "Content-Type": "application/json",
-                        Authorization: `Bearer ${keycloak?.token}`,
-                      },
-                    }
-                  );
-                  Swal.fire({
-                    icon: "error",
-                    title: "Oops...",
-                    text: "Something went wrong! Measurement Property not deleted!",
-                  });
-                }
-              }
-            });
+            openDeleteDialog(row);
           }}
         />
       ),
       flex: 1,
       filter: false,
     },
-  ];
+  ], [isOwner, keycloak?.token, openDeleteDialog, openEditDialog]);
 
   const handlePageChange = (newPage: number) => {
   setPage(newPage);
@@ -464,6 +478,16 @@ and may include a definition or reference for clarity and standardization."
         submitting={saving}
         submitLabel="Save"
         primaryButtonSx={primaryButtonSx}
+        cancelButtonSx={cancelButtonSx}
+      />
+      <ConfirmDeleteDialog
+        open={deleteOpen}
+        title="Delete Measurement Property"
+        entityName={observationPropertyToDelete?.name || ""}
+        description="You will not be able to recover this measurement property. Linked datastreams might become dysfunctional."
+        loading={deleting}
+        onCancel={closeDeleteDialog}
+        onConfirm={confirmDeleteObservationProperty}
         cancelButtonSx={cancelButtonSx}
       />
 

--- a/src/pages/sensors/ListSensors.tsx
+++ b/src/pages/sensors/ListSensors.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import axios from "axios";
 import { useFormik } from "formik";
 import { Breadcrumbs, Button, Typography } from "@mui/material";
@@ -14,6 +14,7 @@ import { GAactionsSensors } from "../../utils/GA";
 import { useAppSelector, useIsOwner } from "../../hooks/hooks";
 import DataTableCardV2 from "../../components/DataGridServerSide";
 import EntityFormModal from "../../components/EntityFormModal";
+import ConfirmDeleteDialog from "../../components/ConfirmDeleteDialog";
 import { editSensorValidationSchema } from "../../formik/validation_schema";
 const ListSensors = () => {
   const { keycloak } = useKeycloak();
@@ -33,6 +34,9 @@ const [sortQuery, setSortQuery] = useState("");
 const [editOpen, setEditOpen] = useState(false);
 const [editingSensorId, setEditingSensorId] = useState<number | null>(null);
 const [saving, setSaving] = useState(false);
+const [deleteOpen, setDeleteOpen] = useState(false);
+const [deleting, setDeleting] = useState(false);
+const [sensorToDelete, setSensorToDelete] = useState<any | null>(null);
   const selectedGroupId = useAppSelector((state) => state.roles.selectedGroupId);
   const group = useAppSelector((state) =>
     state.roles.groups.find((g) => g?.group_name_id === selectedGroupId)
@@ -188,7 +192,65 @@ const [saving, setSaving] = useState(false);
   }
 }, [frostServerPort]);
 
-  const columnDefs = [
+  const openEditDialog = useCallback(
+    (row: any) => {
+      setEditingSensorId(row?.["@iot.id"]);
+      editFormik.setValues({
+        name: row?.name || "",
+        description: row?.description || "",
+        metadata: row?.metadata || "",
+      });
+      setEditOpen(true);
+    },
+    [editFormik.setValues]
+  );
+
+  const openDeleteDialog = useCallback((row: any) => {
+    setSensorToDelete(row);
+    setDeleteOpen(true);
+  }, []);
+
+  const closeDeleteDialog = useCallback(() => {
+    if (deleting) return;
+    setDeleteOpen(false);
+    setSensorToDelete(null);
+  }, [deleting]);
+
+  const confirmDeleteSensor = useCallback(async () => {
+    if (!sensorToDelete) return;
+    try {
+      setDeleting(true);
+      const response = await axios.post(
+        `${process.env.REACT_APP_BACKEND_URL}/delete`,
+        {
+          url: `Sensors(${sensorToDelete["@iot.id"]})`,
+          FROST_PORT: frostServerPort,
+          keycloak_id: userInfo?.sub,
+        },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `${token}`,
+          },
+        }
+      );
+
+      if (response.status === 200) {
+        Swal.fire("Success", "Sensor deleted successfully!", "success");
+        setSensors((prev) => prev.filter((sensor) => sensor["@iot.id"] !== sensorToDelete["@iot.id"]));
+      } else {
+        Swal.fire("Oops...", "Something went wrong! Sensor not deleted!", "error");
+      }
+    } catch {
+      Swal.fire("Oops...", "Something went wrong! Sensor not deleted!", "error");
+    } finally {
+      setDeleting(false);
+      setDeleteOpen(false);
+      setSensorToDelete(null);
+    }
+  }, [frostServerPort, sensorToDelete, token, userInfo?.sub]);
+
+  const columnDefs = useMemo(() => [
     {
       headerName: "ID",
       field: "@iot.id",
@@ -233,13 +295,7 @@ const [saving, setSaving] = useState(false);
           }}
           onClick={() => {
             if (!isOwner) return;
-            setEditingSensorId(params.data?.["@iot.id"]);
-            editFormik.setValues({
-              name: params.data?.name || "",
-              description: params.data?.description || "",
-              metadata: params.data?.metadata || "",
-            });
-            setEditOpen(true);
+            openEditDialog(params.data);
           }}
         />
       ),
@@ -258,51 +314,12 @@ const [saving, setSaving] = useState(false);
           }}
           onClick={() => {
             if (!isOwner) return;
-            Swal.fire({
-              title: `Are you sure you want to delete ${params.data.name}?`,
-              text: "This action cannot be undone. Linked datastreams might break!",
-              icon: "warning",
-              showCancelButton: true,
-              confirmButtonColor: "#3085d6",
-              cancelButtonColor: "#d33",
-              confirmButtonText: "Yes, delete it!",
-            }).then(async (result) => {
-              if (result.isConfirmed) {
-                try {
-                  const response = await axios.post(
-                    `${process.env.REACT_APP_BACKEND_URL}/delete`,
-                    {
-                      url: `Sensors(${params.data["@iot.id"]})`,
-                      FROST_PORT: frostServerPort,
-                      keycloak_id: userInfo?.sub,
-                    },
-                    {
-                      headers: {
-                        "Content-Type": "application/json",
-                        Authorization: `${token}`,
-                      },
-                    }
-                  );
-
-                  if (response.status === 200) {
-                    Swal.fire("Success", "Sensor deleted successfully!", "success");
-                    const newSensors = sensors.filter(
-                      (sensor) => sensor["@iot.id"] !== params.data["@iot.id"]
-                    );
-                    setSensors(newSensors);
-                  } else {
-                    Swal.fire("Oops...", "Something went wrong! Sensor not deleted!", "error");
-                  }
-                } catch (error) {
-                  Swal.fire("Oops...", "Something went wrong! Sensor not deleted!", "error");
-                }
-              }
-            });
+            openDeleteDialog(params.data);
           }}
         />
       ),
     },
-  ];
+  ], [isOwner, openDeleteDialog, openEditDialog]);
 
 
   // onChange 
@@ -406,6 +423,16 @@ Each sensor defines how a measurement is made, including its metadata and descri
         submitting={saving}
         submitLabel="Save"
         primaryButtonSx={primaryButtonSx}
+        cancelButtonSx={cancelButtonSx}
+      />
+      <ConfirmDeleteDialog
+        open={deleteOpen}
+        title="Delete Sensor Type"
+        entityName={sensorToDelete?.name || ""}
+        description="This action cannot be undone. Linked datastreams might break."
+        loading={deleting}
+        onCancel={closeDeleteDialog}
+        onConfirm={confirmDeleteSensor}
         cancelButtonSx={cancelButtonSx}
       />
     </Dashboard>

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -12,7 +12,7 @@ export interface GroupAttributes {
     project_description: string | null;
     attributes: GroupAttributes;
     permissions: string[];
-    role: 'owner' | 'reader';
+    role: 'owner' | 'reader' | 'editor';
   }
   
   export interface ClientRoleMapping {


### PR DESCRIPTION
Implemented role-management and UI consistency updates across frontend:

Added full project authorization flow in ListClients:
approve/reject pending members
assign role on approval (reader/editor)
change role for approved members
remove member
consistent role normalization to avoid false “already assigned” checks
Updated permission behavior so editor has write-level access (same gated paths previously using owner-check hook).
Added live permission refresh for logged-in users on tab focus/visibility.
Added auto-redirect to /dashboard (with refresh) when user is removed from currently selected project.
Improved authorization modal sizing/scroll behavior for consistent UX.
Replaced inconsistent notifications/modals:
Node-RED toggle now uses inline MUI alert above form (auto-hide)
Edit Project now uses shared EntityFormModal pattern for consistency.
Extended role typing to include editor in shared store types.